### PR TITLE
Use Range instead of `start` & `end` in Rope impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 osx_image: xcode9.2
 
 rust:
-  - 1.26.2
+  - 1.28.0
   - nightly
 
 os:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ below.
 ### Building the core
 
 Xi targets 'recent stable Rust'. We recommend installing via [rustup](https://www.rustup.rs).
-The current minimum supported version is 1.26.
+The current minimum supported version is 1.28.
 
 To build the xi editor from the root directory of this repo:
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -602,7 +602,7 @@ impl Editor {
 
     fn sel_region_to_interval_and_rope(&self, region: SelRegion) -> (Interval, Rope) {
         let as_interval = Interval::new_closed_open(region.min(), region.max());
-        let interval_rope = Rope::from(self.text.subseq(as_interval));
+        let interval_rope = self.text.subseq(as_interval);
         (as_interval, interval_rope)
     }
 

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -211,7 +211,7 @@ fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding)
             CharacterEncoding::Utf8 => (),
         }
 
-        for chunk in text.iter_chunks(0, text.len()) {
+        for chunk in text.iter_chunks(..text.len()) {
             f.write_all(chunk.as_bytes())?;
         }
         Ok(())

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -233,14 +233,14 @@ impl Find {
         // aligned to codepoint boundaries.
         let sub_text = text.subseq(Interval::new_closed_open(0, to));
         let mut find_cursor = Cursor::new(&sub_text, from);
-        let mut raw_lines = text.lines_raw(from, to);
+        let mut raw_lines = text.lines_raw(from..to);
 
         while let Some(start) = find(&mut find_cursor, &mut raw_lines, self.case_matching,
                                      &search_string, &self.regex) {
             let end = find_cursor.pos();
 
             if self.whole_words && !self.is_matching_whole_words(text, start, end) {
-                raw_lines = text.lines_raw(find_cursor.pos(), to);
+                raw_lines = text.lines_raw(find_cursor.pos()..to);
                 continue;
             }
 
@@ -253,7 +253,7 @@ impl Find {
                 // the beginning of the file. Re-align the cursor to the kept
                 // occurrence
                 find_cursor.set(e);
-                raw_lines = text.lines_raw(find_cursor.pos(), to);
+                raw_lines = text.lines_raw(find_cursor.pos()..to);
                 continue;
             }
 
@@ -272,7 +272,7 @@ impl Find {
             }
 
             // update line iterator so that line starts at current cursor position
-            raw_lines = text.lines_raw(find_cursor.pos(), to);
+            raw_lines = text.lines_raw(find_cursor.pos()..to);
         }
 
         self.hls_dirty = true;

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -226,7 +226,7 @@ impl<'a> RewrapCtx<'a> {
         while pos < self.max_offset && self.pot_breaks.len() < MAX_POT_BREAKS {
             let (next, hard) = self.lb_cursor.next();
             // TODO: avoid allocating string
-            let word = self.text.slice_to_string(pos, next);
+            let word = self.text.slice_to_string(pos..next);
             let tok = req.request(style_id, &word);
             pos = next;
             self.pot_breaks.push(PotentialBreak { pos, tok, hard });

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -350,14 +350,14 @@ impl SelRegion {
     }
 }
 
-// Returns `[start..end)`
+// Returns `[min..max)`
 impl<'a> RangeBounds<usize> for &'a SelRegion {
     fn start_bound(&self) -> Bound<&usize> {
-        Bound::Included(&self.start)
+        Bound::Included(min(&self.start, &self.end))
     }
     
     fn end_bound(&self) -> Bound<&usize> {
-        Bound::Excluded(&self.end)
+        Bound::Excluded(max(&self.start, &self.end))
     }
 }
 

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -16,6 +16,8 @@
 
 use std::cmp::{min, max};
 use std::ops::Deref;
+use std::ops::Bound;
+use std::ops::RangeBounds;
 
 use index_set::remove_n_at;
 use xi_rope::delta::{Delta, Transformer};
@@ -345,6 +347,17 @@ impl SelRegion {
         // Could try to preserve horiz/affinity from one of the
         // sources, but very likely not worth it.
         SelRegion::new(start, end)
+    }
+}
+
+// Returns `[start..end)`
+impl<'a> RangeBounds<usize> for &'a SelRegion {
+    fn start_bound(&self) -> Bound<&usize> {
+        Bound::Included(&self.start)
+    }
+    
+    fn end_bound(&self) -> Bound<&usize> {
+        Bound::Excluded(&self.end)
     }
 }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -559,7 +559,7 @@ impl View {
             pos
         }).unwrap_or(text.len());
 
-        let l_str = text.slice_to_string(start_pos, pos);
+        let l_str = text.slice_to_string(start_pos..pos);
         let mut cursors = Vec::new();
         let mut selections = Vec::new();
         for region in self.selection.regions_in_range(start_pos, pos) {
@@ -940,13 +940,13 @@ impl View {
         let search_query = match self.selection.last() {
             Some(region) => {
                 if !region.is_caret() {
-                    text.slice_to_string(region.min(), region.max())
+                    text.slice_to_string(region)
                 } else {
                     let (start, end) = {
                         let mut word_cursor = WordCursor::new(text, region.max());
                         word_cursor.select_word()
                     };
-                    text.slice_to_string(start, end)
+                    text.slice_to_string(start..end)
                 }
             },
             _ => return
@@ -1053,13 +1053,13 @@ impl View {
         let replacement = match self.selection.last() {
             Some(region) => {
                 if !region.is_caret() {
-                    text.slice_to_string(region.min(), region.max())
+                    text.slice_to_string(region)
                 } else {
                     let (start, end) = {
                         let mut word_cursor = WordCursor::new(text, region.max());
                         word_cursor.select_word()
                     };
-                    text.slice_to_string(start, end)
+                    text.slice_to_string(start..end)
                 }
             },
             _ => return

--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -433,7 +433,7 @@ mod tests {
             if offset > self.0.len() {
                 Err(Error::Other("offset too big".into()))
             } else {
-                let chunk = self.0.slice_to_string(offset, end_off);
+                let chunk = self.0.slice_to_string(offset..end_off);
                 Ok(GetDataResponse { chunk, offset, first_line, first_line_offset })
             }
         }

--- a/rust/rope/examples/ropetoy.rs
+++ b/rust/rope/examples/ropetoy.rs
@@ -20,16 +20,16 @@ use xi_rope::Rope;
 
 fn main() {
     let mut a = Rope::from("hello.");
-    a.edit_str(5, 6, "!");
+    a.edit_str(5..6, "!");
     for i in 0..1000000 {
         let l = a.len();
-        a.edit_str(l, l, &(i.to_string() + "\n"));
+        a.edit_str(l..l, &(i.to_string() + "\n"));
     }
     let l = a.len();
-    for s in a.clone().iter_chunks(1000, 3000) {
+    for s in a.clone().iter_chunks(1000..3000) {
         println!("chunk {:?}", s);
     }
-    a.edit_str(1000, l, "");
+    a.edit_str(1000..l, "");
     //a = a.subrange(0, 1000);
     println!("{:?}", String::from(a));
 }

--- a/rust/rope/src/find.rs
+++ b/rust/rope/src/find.rs
@@ -316,7 +316,7 @@ mod tests {
     fn find_small() {
         let a = Rope::from("Löwe 老虎 Léopard");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(..);
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(0));
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(13));
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), None);
@@ -343,7 +343,7 @@ mod tests {
         s.push_str("Löwe 老虎 Léopard");
         let a = Rope::from(&s);
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(4000));
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(4013));
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), None);
@@ -364,7 +364,7 @@ mod tests {
     fn find_casei_small() {
         let a = Rope::from("Löwe 老虎 Léopard");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), Some(0));
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), Some(13));
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), None);
@@ -385,7 +385,7 @@ mod tests {
     fn find_casei_ascii_nonalpha() {
         let a = Rope::from("![cfg(test)]");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(test)", &None), Some(5));
         c.set(0);
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(TEST)", &None), Some(5));
@@ -395,7 +395,7 @@ mod tests {
     fn find_casei_special() {
         let a = Rope::from("İ");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i̇", &None), Some(0));
 
         let a = Rope::from("i̇");
@@ -415,7 +415,7 @@ mod tests {
     fn find_casei_0xc4() {
         let a = Rope::from("\u{0100}I");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i", &None), Some(2));
     }
 
@@ -423,16 +423,16 @@ mod tests {
     fn find_regex_small_casei() {
         let a = Rope::from("Löwe 老虎 Léopard\nSecond line");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("L")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(0));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(13));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(29));
         c.set(0);
         let regex = RegexBuilder::new("Léopard")
@@ -440,19 +440,19 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), Some(13));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), None);
         c.set(0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("老虎")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), Some(6));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
@@ -460,7 +460,7 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new(".")
@@ -468,16 +468,16 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", &regex), Some(0));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", &regex), Some(5));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
@@ -490,16 +490,16 @@ mod tests {
     fn find_regex_small() {
         let a = Rope::from("Löwe 老虎 Léopard\nSecond line");
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("L")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(false)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), Some(0));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), Some(13));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("Léopard")
@@ -507,9 +507,9 @@ mod tests {
             .case_insensitive(false)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &regex), Some(13));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("老虎")
@@ -517,9 +517,9 @@ mod tests {
             .case_insensitive(false)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &regex), Some(6));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
@@ -527,7 +527,7 @@ mod tests {
             .case_insensitive(false)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new(".")
@@ -535,16 +535,16 @@ mod tests {
             .case_insensitive(false)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, Exact, ".", &regex), Some(0));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(false)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, Exact, "\\s", &regex), Some(5));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(false)
@@ -562,26 +562,26 @@ mod tests {
         s.push_str("Löwe 老虎 Léopard\nSecond line");
         let a = Rope::from(&s);
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("L")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4000));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4013));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4029));
         c.set(0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("Léopard")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), Some(4013));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("老虎")
@@ -589,9 +589,9 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), Some(4006));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
@@ -599,24 +599,24 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", &regex), None);
         c.set(0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new(".")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", &regex), Some(0));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
         assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", &regex), Some(4005));
-        raw_lines = a.lines_raw(c.pos(), a.len());
+        raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
@@ -630,7 +630,7 @@ mod tests {
         let a = Rope::from("Löwe 老虎 Léopard");
         let mut c = Cursor::new(&a, 0);
         let pat = "Löwe 老虎 Léopard";
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert!(compare_cursor_str(&mut c, &mut raw_lines, pat).is_some());
         assert_eq!(c.pos(), pat.len());
         c.set(0);
@@ -655,7 +655,7 @@ mod tests {
         s.push_str("Löwe 老虎 Léopard");
         let a = Rope::from(&s);
         let mut c = Cursor::new(&a, 0);
-        let mut raw_lines = a.lines_raw(0, a.len());
+        let mut raw_lines = a.lines_raw(0..a.len());
         assert!(compare_cursor_str(&mut c, &mut raw_lines, &s).is_some());
         assert_eq!(c.pos(), s.len());
         c.set(2000);

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -22,6 +22,8 @@ use std::ops::Add;
 use std::str;
 use std::str::FromStr;
 use std::string::ParseError;
+use std::ops::Bound;
+use std::ops::RangeBounds;
 
 use delta::{Delta, DeltaElement};
 use interval::Interval;
@@ -74,9 +76,9 @@ const MAX_LEAF: usize = 1024;
 /// ```rust
 /// # use xi_rope::Rope;
 /// let a = Rope::from("hello world");
-/// let b = a.slice(1, 9);
+/// let b = a.slice(1..9);
 /// assert_eq!("ello wor", String::from(&b));
-/// let c = b.slice(1, 7);
+/// let c = b.slice(1..7);
 /// assert_eq!("llo wo", String::from(c));
 /// ```
 ///
@@ -85,7 +87,7 @@ const MAX_LEAF: usize = 1024;
 /// ```rust
 /// # use xi_rope::Rope;
 /// let mut a = Rope::from("hello world");
-/// a.edit_str(1, 9, "era");
+/// a.edit_str(1..9, "era");
 /// assert_eq!("herald", String::from(a));
 /// ```
 pub type Rope = Node<RopeInfo>;
@@ -478,7 +480,11 @@ impl Rope {
     /// Note: `edit` and `edit_str` may be merged, using traits.
     ///
     /// Time complexity: O(log n)
-    pub fn edit_str(&mut self, start: usize, end: usize, new: &str) {
+    pub fn edit_str<T>(&mut self, range: T, new: &str) 
+        where T: RangeBounds<usize> 
+    {
+        let (start, end) = self.extract_range(range);
+
         let mut b = TreeBuilder::new();
         // TODO: may make this method take the iv directly
         let edit_iv = Interval::new_closed_open(start, end);
@@ -489,8 +495,12 @@ impl Rope {
         *self = b.build();
     }
 
-    /// Returns a slice of the string from the byte range [`start`..`end`).
-    pub fn slice(&self, start: usize, end: usize) -> Rope {
+    /// Returns a new Rope with the contents of the provided range.
+    pub fn slice<T>(&self, range: T) -> Rope 
+        where T: RangeBounds<usize>
+    {
+        let (start, end) = self.extract_range(range);
+
         let iv = Interval::new_closed_open(start, end);
         self.subseq(iv)
     }
@@ -574,16 +584,15 @@ impl Rope {
     ///
     /// Time complexity: technically O(n log n), but the constant factor is so
     /// tiny it is effectively O(n). This iterator does not allocate.
-    pub fn iter_chunks(&self, start: usize, end: usize) -> ChunkIter {
+    pub fn iter_chunks<T>(&self, range: T) -> ChunkIter 
+        where T: RangeBounds<usize>
+    {
+        let (start, end) = self.extract_range(range);
+
         ChunkIter {
             cursor: Cursor::new(self, start),
-            end,
+            end: end,
         }
-    }
-
-    //TODO: implement iter_chunks using ranges and delete this
-    pub fn iter_chunks_all(&self) -> ChunkIter {
-        self.iter_chunks(0, self.len())
     }
 
     /// An iterator over the raw lines. The lines, except the last, include the
@@ -591,16 +600,13 @@ impl Rope {
     ///
     /// The return type is a `Cow<str>`, and in most cases the lines are slices
     /// borrowed from the rope.
-    pub fn lines_raw(&self, start: usize, end: usize) -> LinesRaw {
+    pub fn lines_raw<T>(&self, range: T) -> LinesRaw 
+        where T: RangeBounds<usize>
+    {
         LinesRaw {
-            inner: self.iter_chunks(start, end),
+            inner: self.iter_chunks(range),
             fragment: "",
         }
-    }
-
-    //TODO: implement lines_raw using ranges and delete this
-    pub fn lines_raw_all(&self) -> LinesRaw {
-        self.lines_raw(0, self.len())
     }
 
     /// An iterator over the lines of a rope.
@@ -613,15 +619,12 @@ impl Rope {
     /// from the rope.
     ///
     /// The semantics are intended to match `str::lines()`.
-    pub fn lines(&self, start: usize, end: usize) -> Lines {
+    pub fn lines<T>(&self, range: T) -> Lines
+        where T: RangeBounds<usize>
+    {
         Lines {
-            inner: self.lines_raw(start, end),
+            inner: self.lines_raw(range)
         }
-    }
-
-    // TODO: replace this with a version of `lines` that accepts a range
-    pub fn lines_all(&self) -> Lines {
-        self.lines(0, self.len())
     }
 
     // callers should be encouraged to use cursor instead
@@ -633,12 +636,33 @@ impl Rope {
 
     // TODO: this should be a Cow
     // TODO: a case can be made to hang this on Cursor instead
-    pub fn slice_to_string(&self, start: usize, end: usize) -> String {
+    pub fn slice_to_string<T>(&self, range: T) -> String 
+        where T: RangeBounds<usize>
+    {
         let mut result = String::new();
-        for chunk in self.iter_chunks(start, end) {
+        for chunk in self.iter_chunks(range) {
             result.push_str(chunk);
         }
         result
+    }
+    
+    /// Extracts start and end bounds from a range
+    fn extract_range<T>(&self, range: T) -> (usize, usize)
+        where T: RangeBounds<usize>
+    {
+        let start = match range.start_bound() {
+            Bound::Included(n) => *n,
+            Bound::Excluded(n) => *n + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(n) => *n + 1,
+            Bound::Excluded(n) => *n,
+            Bound::Unbounded => self.len(),
+        };
+
+        (start, end)
     }
 }
 
@@ -728,7 +752,7 @@ impl From<Rope> for String {
 
 impl<'a> From<&'a Rope> for String {
     fn from(r: &Rope) -> String {
-        r.slice_to_string(0, r.len())
+        r.slice_to_string(..)
     }
 }
 
@@ -924,71 +948,57 @@ mod tests {
     #[test]
     fn replace_small() {
         let mut a = Rope::from("hello world");
-        a.edit_str(1, 9, "era");
+        a.edit_str(1..9, "era");
         assert_eq!("herald", String::from(a));
     }
 
     #[test]
     fn lines_raw_small() {
         let a = Rope::from("a\nb\nc");
-        assert_eq!(
-            vec!["a\n", "b\n", "c"],
-            a.lines_raw_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec!["a\n", "b\n", "c"], a.lines_raw(..).collect::<Vec<_>>());
+        assert_eq!(vec!["a\n", "b\n", "c"], a.lines_raw(..).collect::<Vec<_>>());
 
         let a = Rope::from("a\nb\n");
-        assert_eq!(vec!["a\n", "b\n"], a.lines_raw_all().collect::<Vec<_>>());
+        assert_eq!(vec!["a\n", "b\n"], a.lines_raw(..).collect::<Vec<_>>());
 
         let a = Rope::from("\n");
-        assert_eq!(vec!["\n"], a.lines_raw_all().collect::<Vec<_>>());
+        assert_eq!(vec!["\n"], a.lines_raw(..).collect::<Vec<_>>());
 
         let a = Rope::from("");
-        assert_eq!(0, a.lines_raw_all().count());
+        assert_eq!(0, a.lines_raw(..).count());
     }
 
     #[test]
     fn lines_small() {
         let a = Rope::from("a\nb\nc");
-        assert_eq!(vec!["a", "b", "c"], a.lines_all().collect::<Vec<_>>());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec!["a", "b", "c"], a.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+        a.lines(..).collect::<Vec<_>>());
 
         let a = Rope::from("a\nb\n");
-        assert_eq!(vec!["a", "b"], a.lines_all().collect::<Vec<_>>());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec!["a", "b"], a.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+        a.lines(..).collect::<Vec<_>>());
 
         let a = Rope::from("\n");
-        assert_eq!(vec![""], a.lines_all().collect::<Vec<_>>());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec![""], a.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+        a.lines(..).collect::<Vec<_>>());
 
         let a = Rope::from("");
-        assert_eq!(0, a.lines_all().count());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(0, a.lines(..).count());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+        a.lines(..).collect::<Vec<_>>());
 
         let a = Rope::from("a\r\nb\r\nc");
-        assert_eq!(vec!["a", "b", "c"], a.lines_all().collect::<Vec<_>>());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec!["a", "b", "c"], a.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+        a.lines(..).collect::<Vec<_>>());
 
         let a = Rope::from("a\rb\rc");
-        assert_eq!(vec!["a\rb\rc"], a.lines_all().collect::<Vec<_>>());
-        assert_eq!(
-            String::from(&a).lines().collect::<Vec<_>>(),
-            a.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec!["a\rb\rc"], a.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&a).lines().collect::<Vec<_>>(),
+               a.lines(..).collect::<Vec<_>>());
     }
 
     #[test]
@@ -1007,18 +1017,10 @@ mod tests {
         let r = r + Rope::from(&b[MIN_LEAF..]);
         //println!("{:?}", r.iter_chunks().collect::<Vec<_>>());
 
-        assert_eq!(
-            vec![a.as_str(), b.as_str()],
-            r.lines_raw_all().collect::<Vec<_>>()
-        );
-        assert_eq!(
-            vec![&a[..line_len], &b[..line_len]],
-            r.lines_all().collect::<Vec<_>>()
-        );
-        assert_eq!(
-            String::from(&r).lines().collect::<Vec<_>>(),
-            r.lines_all().collect::<Vec<_>>()
-        );
+        assert_eq!(vec![a.as_str(), b.as_str()], r.lines_raw(..).collect::<Vec<_>>());
+        assert_eq!(vec![&a[..line_len], &b[..line_len]], r.lines(..).collect::<Vec<_>>());
+        assert_eq!(String::from(&r).lines().collect::<Vec<_>>(),
+                   r.lines(..).collect::<Vec<_>>());
 
         // additional tests for line indexing
         assert_eq!(a.len(), r.offset_of_line(1));
@@ -1049,7 +1051,7 @@ mod tests {
         assert_eq!(Some(1), a.prev_codepoint_offset(3));
         assert_eq!(Some(0), a.prev_codepoint_offset(1));
         assert_eq!(None, a.prev_codepoint_offset(0));
-        let b = a.slice(1, 10);
+        let b = a.slice(1..10);
         assert_eq!(Some(5), b.prev_codepoint_offset(9));
         assert_eq!(Some(2), b.prev_codepoint_offset(5));
         assert_eq!(Some(0), b.prev_codepoint_offset(2));
@@ -1064,7 +1066,7 @@ mod tests {
         assert_eq!(Some(3), a.next_codepoint_offset(1));
         assert_eq!(Some(1), a.next_codepoint_offset(0));
         assert_eq!(None, a.next_codepoint_offset(10));
-        let b = a.slice(1, 10);
+        let b = a.slice(1..10);
         assert_eq!(Some(9), b.next_codepoint_offset(5));
         assert_eq!(Some(5), b.next_codepoint_offset(2));
         assert_eq!(Some(2), b.next_codepoint_offset(0));
@@ -1132,7 +1134,7 @@ mod tests {
         assert_eq!(1, a.line_of_offset(3));
         assert_eq!(2, a.line_of_offset(4));
         assert_eq!(2, a.line_of_offset(5));
-        let b = a.slice(2, 4);
+        let b = a.slice(2..4);
         assert_eq!(0, b.line_of_offset(0));
         assert_eq!(0, b.line_of_offset(1));
         assert_eq!(1, b.line_of_offset(2));
@@ -1145,7 +1147,7 @@ mod tests {
         assert_eq!(2, a.offset_of_line(1));
         assert_eq!(4, a.offset_of_line(2));
         assert_eq!(5, a.offset_of_line(3));
-        let b = a.slice(2, 4);
+        let b = a.slice(2..4);
         assert_eq!(0, b.offset_of_line(0));
         assert_eq!(2, b.offset_of_line(1));
     }
@@ -1160,7 +1162,7 @@ mod tests {
         assert!(a != b);
         assert!(a != empty);
         assert!(empty == empty);
-        assert!(a.slice(0, 0) == empty);
+        assert!(a.slice(0..0) == empty);
     }
 
     #[test]
@@ -1181,8 +1183,8 @@ mod tests {
         let a_rope = Rope::from(&a);
         let b_rope = Rope::from(&b);
         assert!(r != a_rope);
-        assert!(r.clone().slice(0, a.len()) == a_rope);
-        assert!(r.clone().slice(a.len(), r.len()) == b_rope);
+        assert!(r.clone().slice(..a.len()) == a_rope);
+        assert!(r.clone().slice(a.len()..) == b_rope);
         assert!(r == a_rope.clone() + b_rope.clone());
         assert!(r != b_rope + a_rope);
     }


### PR DESCRIPTION
Closes #571 
Related to #575 

Realized that `slice_to_string` isn't a function that returns an iterator, as per the request in #571 - maybe I should change that back?

Hoping I'm on the right track here. :)
cc @cmyr 

---
TODO:
- [x] Change functions returning iterators, so they now use `RangeBounds` instead of `start` and `end`
- [x] Update tests
- [x] Update external calls to changed functions
- [x] Wait for RangeBounds to become stable