### PR TITLE
Autodetect tab and newline when opening a file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Araz Abishov
 Lê Viết Hoàng Dũng
 Markus Ast
 Raph Levien
+Hilmar Gústafsson

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1006,6 +1006,7 @@ name = "xi-core-lib"
 version = "0.2.0"
 dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -15,6 +15,7 @@ time = "0.1"
 toml = "0.4"
 notify = { optional = true, version = "4.0" }
 regex = "1.0"
+memchr = "2.0.1"
 
 xi-trace = { path = "../trace", version = "0.1.0" }
 xi-trace-dump = { path = "../trace-dump", version = "0.1.0" }

--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -36,3 +36,6 @@ wrap_width = 0
 
 # If true, wraps lines at the edge of the view. Overrides 'wrap_width'.
 word_wrap = false
+
+# Detect tab and newline settings on file open
+autodetect_whitespace = true

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -24,3 +24,5 @@ scroll_past_end = false
 wrap_width = 0
 
 word_wrap = false
+
+autodetect_whitespace = true

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -170,6 +170,7 @@ pub struct BufferItems {
     pub scroll_past_end: bool,
     pub wrap_width: usize,
     pub word_wrap: bool,
+    pub autodetect_whitespace: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -44,6 +44,7 @@ extern crate syntect;
 extern crate toml;
 #[cfg(feature = "notify")]
 extern crate notify;
+extern crate memchr;
 
 extern crate xi_rope;
 extern crate xi_rpc;
@@ -89,6 +90,8 @@ pub mod config;
 pub mod watcher;
 pub mod line_cache_shadow;
 pub mod width_cache;
+pub mod whitespace;
+pub mod line_ending;
 
 pub mod rpc;
 

--- a/rust/core-lib/src/line_ending.rs
+++ b/rust/core-lib/src/line_ending.rs
@@ -1,0 +1,96 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for detecting and working with line endings
+
+extern crate xi_rope;
+
+use xi_rope::Rope;
+use memchr::memchr2;
+
+/// An enumeration of valid line endings
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LineEnding {
+    CrLf,   // DOS style, \r\n
+    Lf,     // *nix style, \n
+}
+
+/// A struct representing a mixed line ending error.
+#[derive(Debug)]
+pub struct MixedLineEndingError;
+
+impl LineEnding {
+    /// Breaks a rope down into chunks, and checks each chunk for line endings
+    pub fn parse(rope: &Rope) -> Result<Option<Self>, MixedLineEndingError> {
+        let mut crlf = false;
+        let mut lf = false;
+
+        for chunk in rope.iter_chunks(..) {
+            match LineEnding::parse_chunk(&chunk) {
+                Ok(Some(LineEnding::CrLf)) => crlf = true,
+                Ok(Some(LineEnding::Lf)) => lf = true,
+                Ok(None) => (),
+                Err(e) => return Err(e),
+            }
+        }
+
+        match (crlf, lf) {
+            (true, false) => Ok(Some(LineEnding::CrLf)),
+            (false, true) => Ok(Some(LineEnding::Lf)),
+            (false, false) => Ok(None),
+            _ => Err(MixedLineEndingError),
+        }
+    }
+
+    /// Checks a chunk for line endings, assuming \n or \r\n
+    pub fn parse_chunk(chunk: &str) -> Result<Option<Self>, MixedLineEndingError> {
+        let bytes = chunk.as_bytes();
+        let newline = memchr2(b'\n', b'\r', bytes);
+        match newline {
+            Some(x) if bytes[x] == b'\r' && bytes.len() > x + 1 && bytes[x + 1] == b'\n' => Ok(Some(LineEnding::CrLf)),
+            Some(x) if bytes[x] == b'\n' => Ok(Some(LineEnding::Lf)),
+            Some(_) => Err(MixedLineEndingError),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crlf() {
+        let result = LineEnding::parse_chunk("\r\n");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(LineEnding::CrLf));
+    }
+
+    #[test]
+    fn lf() {
+        let result = LineEnding::parse_chunk("\n");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(LineEnding::Lf));
+    }
+
+    #[test]
+    fn legacy_mac_errors() {
+        assert!(LineEnding::parse_chunk("\r").is_err());
+    }
+
+    #[test]
+    fn bad_space() {
+        assert!(LineEnding::parse_chunk("\r \n").is_err());
+    }
+}

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -605,10 +605,10 @@ impl CoreState {
         }
 
         let config_delta = self.config_manager.table_for_update(ConfigDomain::SysOverride(buffer_id), changes);
-        match self.config_manager.set_user_config(ConfigDomain::SysOverride(buffer_id), config_delta.clone()) {
-            Ok(ref items) if items.len() > 0 => {
+        match self.config_manager.set_user_config(ConfigDomain::SysOverride(buffer_id), config_delta) {
+            Ok(ref mut items) if items.len() > 0 => {
                 assert!(items.len() == 1, "whitespace overrides can only update a single buffer's config\n{:?}", items);
-                let table = items.first().unwrap().1.to_owned();
+                let table = items.remove(0).1;
                 let mut config = config.clone();
                 config.extend(table);
                 Some(config)

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -49,6 +49,8 @@ use styles::{ThemeStyleMap, DEFAULT_THEME};
 use view::View;
 use width_cache::WidthCache;
 use syntax::LanguageId;
+use whitespace::Indentation;
+use line_ending::LineEnding;
 
 #[cfg(feature = "notify")]
 use watcher::{FileWatcher, WatchToken};
@@ -559,9 +561,67 @@ impl CoreState {
     fn finalize_new_views(&mut self) {
         let to_start = mem::replace(&mut self.pending_views, Vec::new());
         to_start.iter().for_each(|(id, config)| {
+            let modified = self.detect_whitespace(*id, config); 
+            let config = modified.as_ref().unwrap_or(config);
             let mut edit_ctx = self.make_context(*id).unwrap();
-            edit_ctx.finish_init(config);
+            edit_ctx.finish_init(&config);
         });
+    }
+
+    // Detects whitespace settings from the file and merges them with the config
+    fn detect_whitespace(&mut self, id: ViewId, config: &Table) -> Option<Table> {
+        let buffer_id = self.views.get(&id).map(|v| v.borrow().get_buffer_id())?;
+        let editor = self.editors.get(&buffer_id).expect("existing buffer_id must have corresponding editor");
+
+        let autodetect_whitespace = self.config_manager.get_buffer_config(buffer_id).items.autodetect_whitespace;
+        if !autodetect_whitespace {
+            return None;
+        }
+
+        let mut changes = Table::new();
+        let indentation = Indentation::parse(editor.borrow().get_buffer());
+        match indentation {
+            Ok(Some(Indentation::Tabs)) => {
+                changes.insert("translate_tabs_to_spaces".into(), false.into());
+            },
+            Ok(Some(Indentation::Spaces(n))) => {
+                changes.insert("translate_tabs_to_spaces".into(), true.into());
+                changes.insert("tab_size".into(), n.into());
+            },
+            Err(_) => info!("detected mixed indentation"),
+            Ok(None) => info!("file contains no indentation"),
+        }
+
+        let line_ending = LineEnding::parse(editor.borrow().get_buffer());
+        match line_ending {
+            Ok(Some(LineEnding::CrLf)) => {
+                changes.insert("line_ending".into(), "\r\n".into());
+            },
+            Ok(Some(LineEnding::Lf)) => {
+                changes.insert("line_ending".into(), "\n".into());
+            },
+            Err(_) => info!("detected mixed line endings"),
+            Ok(None) => info!("file contains no supported line endings"),
+        }
+
+        let config_delta = self.config_manager.table_for_update(ConfigDomain::SysOverride(buffer_id), changes);
+        match self.config_manager.set_user_config(ConfigDomain::SysOverride(buffer_id), config_delta.clone()) {
+            Ok(ref items) if items.len() > 0 => {
+                assert!(items.len() == 1, "whitespace overrides can only update a single buffer's config\n{:?}", items);
+                let table = items.first().unwrap().1.to_owned();
+                let mut config = config.clone();
+                config.extend(table);
+                Some(config)
+            },
+            Ok(_) => {
+                warn!("set_user_config failed to update config, no tables were returned");
+                None
+            },
+            Err(err) => {
+                warn!("detect_whitespace failed to update config: {:?}", err);
+                None
+            },
+        }
     }
 
     fn handle_render_timer(&mut self, token: usize) {

--- a/rust/core-lib/src/whitespace.rs
+++ b/rust/core-lib/src/whitespace.rs
@@ -1,0 +1,186 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for detecting and working with indentation.
+
+extern crate xi_rope;
+
+use xi_rope::Rope;
+use std::collections::BTreeMap;
+
+/// An enumeration of legal indentation types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Indentation {
+    Tabs,
+    Spaces(usize),
+}
+
+/// A struct representing the mixed indentation error.
+#[derive(Debug)]
+pub struct MixedIndentError;
+
+impl Indentation {
+    /// Parses a rope for indentation settings.
+    pub fn parse(rope: &Rope) -> Result<Option<Self>, MixedIndentError> {
+        let lines = rope.lines_raw(..);
+        let mut tabs = false;
+        let mut spaces: BTreeMap<usize, usize> = BTreeMap::new();
+
+        for line in lines {
+            match Indentation::parse_line(&line) {
+                Ok(Some(Indentation::Spaces(size))) => { 
+                    let counter = spaces.entry(size).or_insert(0);
+                    *counter += 1;
+                },
+                Ok(Some(Indentation::Tabs)) => tabs = true,
+                Ok(None) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        match (tabs, spaces.len() > 0) {
+            (true, true) => Err(MixedIndentError),
+            (true, false) => Ok(Some(Indentation::Tabs)),
+            (false, true) => Ok(Some(Indentation::Spaces(extract_count(spaces)))),
+            _ => Ok(None),
+        }
+    }
+
+    /// Detects the indentation on a specific line.
+    /// Parses whitespace until first occurrence of something else
+    pub fn parse_line(line: &str) -> Result<Option<Self>, MixedIndentError> {
+        let mut spaces = 0;
+
+        for char in line.as_bytes() {
+            match char {
+                b' ' => spaces += 1,
+                b'\t' if spaces > 0 => return Err(MixedIndentError),
+                b'\t' => return Ok(Some(Indentation::Tabs)),
+                _ => break,
+            }
+        }
+
+        if spaces > 0 {
+            Ok(Some(Indentation::Spaces(spaces)))
+        }
+        else {
+            Ok(None)
+        }
+    }
+}
+
+/// Uses a heuristic to calculate the greatest common denominator of most used indentation depths.
+/// 
+/// As BTreeMaps are ordered by value, using take on the iterator ensures the indentation levels
+/// most frequently used in the file are extracted.
+fn extract_count(spaces: BTreeMap<usize, usize>) -> usize {
+    let mut take_size = 4;
+
+    if spaces.len() < take_size {
+        take_size = spaces.len();
+    }
+
+    // Fold results using GCD, skipping numbers which result in gcd returning 1
+    spaces.iter().take(take_size)
+    .fold(0, |a, (b, _)| {
+        let d = gcd(a, *b); 
+        if d == 1 {
+            return a;
+        } else {
+            return d;
+        }
+    })
+}
+
+/// Simple implementation to calculate greatest common divisor, based on Euclid's algorithm
+fn gcd(a: usize, b: usize) -> usize {
+    if a == 0 {
+        b
+    } else if b == 0 || a == b {
+        a
+    } else {
+        let mut a = a;
+        let mut b = b;
+        
+        while b > 0 {
+            let r = a % b;
+            a = b;
+            b = r;
+        }
+        a
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gcd_calculates_correctly() {
+        assert_eq!(21, gcd(1071, 462));
+        assert_eq!(6, gcd(270, 192));
+    }
+
+    #[test]
+    fn line_gets_two_spaces() {
+        let result = Indentation::parse_line("  ");
+        let expected = Indentation::Spaces(2);
+
+        assert_eq!(result.unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn line_gets_tabs() {
+        let result = Indentation::parse_line("\t");
+        let expected = Indentation::Tabs;
+
+        assert_eq!(result.unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn line_errors_mixed_indent() {
+        let result = Indentation::parse_line("  \t");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rope_gets_two_spaces() {
+        let result = Indentation::parse(&Rope::from(r#"
+        // This is a comment
+          Testing
+          Indented
+            Even more indented
+            # Comment
+            # Comment
+            # Comment
+        "#));
+        let expected = Indentation::Spaces(2);
+
+        assert_eq!(result.unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn rope_gets_four_spaces() {
+        let result = Indentation::parse(&Rope::from(r#"
+        fn my_fun_func(&self,
+                       another_arg: usize) -> Fun {
+            /* Random comment describing program behavior */
+            Fun::from(another_arg)
+        }
+        "#));
+        let expected = Indentation::Spaces(4);
+
+        assert_eq!(result.unwrap(), Some(expected));
+    }
+}


### PR DESCRIPTION
Closes #411

- [x] Add config option for auto detecting whitespace
- [x] Activate whitespace detection on file open, if turned on
- [x] Parse files for tab settings (tabs, spaces, mixed?)
- [ ] ~~Bonus: Fix whitespace inconsistency (option based as well, maybe?)~~

Will add more info as I progress.

*Note:* It seems that adding the setting makes tests such as `test_overrides` to fail, not really sure why.
```
---- internal::config::tests::test_overrides stdout ----
        thread 'internal::config::tests::test_overrides' panicked at 'called `Result::unwrap()` on an `Err` value: UnexpectedItem(Error("missing field `autodetect_whitespace`", line: 0, column: 0))', libcore\result.rs:945:5
```
Seems like a default for autodetect_whitespace is not generated by ConfigManager is my most educated guess, I'll look into it on Wednesday.