### PR TITLE
Preliminary cursor info status item support

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -36,3 +36,6 @@ wrap_width = 0
 
 # If true, wraps lines at the edge of the view. Overrides 'wrap_width'.
 word_wrap = false
+
+# If true, shows the cursor position or selections count as a status item.
+show_cursor_status = false

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -24,3 +24,5 @@ scroll_past_end = false
 wrap_width = 0
 
 word_wrap = false
+
+show_cursor_status = false

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -165,6 +165,7 @@ pub struct BufferItems {
     pub scroll_past_end: bool,
     pub wrap_width: usize,
     pub word_wrap: bool,
+    pub show_cursor_status: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -55,6 +55,8 @@ pub const MAX_SIZE_LIMIT: usize = 1024 * 1024;
 /// window will be sent to the view along with the edit.
 const RENDER_DELAY: Duration = Duration::from_millis(2);
 
+const SELECTION_STATUS_ITEM_KEY: &str = "xi-editor.io.status.selections";
+
 /// A collection of all the state relevant for handling a particular event.
 ///
 /// This is created dynamically for each event that arrives to the core,
@@ -278,7 +280,16 @@ impl<'a> EventContext<'a> {
         //TODO: render other views
         self.view.borrow_mut()
             .render_if_dirty(ed.get_buffer(), self.client, self.style_map,
-                             ed.get_layers().get_merged(), ed.is_pristine())
+                             ed.get_layers().get_merged(), ed.is_pristine());
+
+        if self.config.show_cursor_status {
+            let status_msg = self.view.borrow()
+                .get_selection_status_text(ed.get_buffer());
+            self.client.update_status_item(self.view_id,
+                                           SELECTION_STATUS_ITEM_KEY,
+                                           &status_msg);
+        }
+
     }
 }
 
@@ -304,6 +315,9 @@ impl<'a> EventContext<'a> {
 
         self.client.config_changed(self.view_id, config);
         self.update_wrap_state();
+        if self.config.show_cursor_status {
+            self.setup_selection_status_item();
+        }
         self.render()
     }
 
@@ -330,6 +344,10 @@ impl<'a> EventContext<'a> {
         if changes.contains_key("wrap_width")
             || changes.contains_key("word_wrap") {
             self.update_wrap_state();
+        }
+
+        if changes.contains_key("show_cursor_status") {
+            self.setup_selection_status_item();
         }
 
         self.client.config_changed(self.view_id, &changes);
@@ -413,6 +431,18 @@ impl<'a> EventContext<'a> {
             });
         }
         self.render();
+    }
+
+    fn setup_selection_status_item(&self) {
+        if self.config.show_cursor_status {
+            self.client.add_status_item(self.view_id,
+                                        "core",
+                                        SELECTION_STATUS_ITEM_KEY,
+                                        "",
+                                        "left");
+        } else {
+            self.client.remove_status_item(self.view_id, SELECTION_STATUS_ITEM_KEY);
+        }
     }
 
     fn do_request_lines(&mut self, first: usize, last: usize) {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -193,6 +193,27 @@ impl View {
         self.pending_render
     }
 
+    /// Returns a string description of the selection state, suitable for
+    /// display in an editor's statusbar.
+    pub(crate) fn get_selection_status_text(&self, text: &Rope) -> String {
+        let _t = trace_block("View::get_selection_status_text", &["core"]);
+        match self.selection.len() {
+            0 => "".into(),
+            1 if self.selection[0].is_caret() => {
+                let offset = self.selection[0].start;
+                let (line, col) = self.offset_to_line_col(text, offset);
+                format!("Line: {}, Column: {}", line + 1, col)
+            }
+            1 => {
+                let sel_size = self.selection[0].max() - self.selection[0].min();
+                // I don't want to get the text and count the chars here,
+                // but I'm not sure what the shortcut is.
+                format!("Selected {} bytes", sel_size)
+            }
+            other => format!("{} active cursors", other)
+        }
+    }
+
     pub(crate) fn do_edit(&mut self, text: &Rope, cmd: ViewEvent) {
         use self::ViewEvent::*;
         match cmd {


### PR DESCRIPTION
This shouldn't be merged in its current state, and is intended as a way of getting a better feel for the statusbar added in https://github.com/google/xi-mac/pull/183.

@raphlinus you can give this + that a try at some point.

@nangtrongvuon you might want to give this a read too?
