### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,35 @@
+env:
+  CARGO_HOME: /tmp/cargo
+
+task:
+  matrix:
+    - install_cmake_script: apt-get update && apt-get install -y cmake
+      matrix:
+        - name: test (linux)
+          container:
+            image: rust:latest
+            cpu: 4
+            memory: 8G
+        - name: test (linux nightly)
+          allow_failures: true
+          container:
+            image: rustlang/rust:nightly
+            cpu: 4
+            memory: 8G
+    - osx_instance:
+        image: high-sierra-xcode-9.4
+      env:
+        PATH: $PATH:$CARGO_HOME/bin
+      install_cmake_script: brew install cmake
+      matrix:
+        - name: test (macOS)
+          install_rust_script: curl https://sh.rustup.rs -sSf | sh -s -- -y
+        - name: test (macOS nightly)
+          allow_failures: true
+          install_rust_script: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+  cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat rust/Cargo.lock
+  build_script: cd rust && cargo build --verbose --all --jobs 4
+  test_script: cd rust && cargo test --verbose --all --jobs 4
+  before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
Since you liked my tweaks to CI config in #730 I decided to propose a more radical approach which gives  **almost 3x performance improvement**. Switch the CI (for now just to run in parallel with Travis CI for evaluation). Feel free to close the PR if it's not interesting.

Here are a few wins of using Cirrus CI:
* CI times for Linux builds improved from ~9 minutes to ~3 minutes thanks to fast caching and using containers with 4CPUs and 8Gb of memory.
* Cirrus CI uses the **official** Docker Images for Rust and Rust Nightly.
* macOS builds are pretty much the same.
* This PR configures only Linux and macOS builds but Cirrus CI supports Windows for when you'll start testing on Windows.

Here is an example of [a build for this change](https://cirrus-ci.com/build/5738995405291520):

![image](https://user-images.githubusercontent.com/989066/42195861-0ab84762-7e49-11e8-8b7c-99f6805e02a5.png)

And [a particular task](https://cirrus-ci.com/task/5666411531730944) of the build:

![image](https://user-images.githubusercontent.com/989066/42195880-292e4aca-7e49-11e8-8811-54225d6d129e.png)

Cirrus CI also shows a more fine grained status checks for PRs:

![image](https://user-images.githubusercontent.com/989066/42195960-7340e1d6-7e49-11e8-8adf-544b0cfca69d.png)

Please feel free to close the PR. But in case you'll decide to merge, and admin of GitHub Google Organization should configure [Cirrus CI App](https://github.com/marketplace/cirrus-ci) for free for this public repository.
