### PR TITLE
Definition support in the Language Server Plugin

### DIFF
--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -22,7 +22,7 @@ use xi_rpc::{self, RpcPeer};
 use tabs::ViewId;
 use config::Table;
 use styles::ThemeSettings;
-use plugins::rpc::ClientPluginInfo;
+use plugins::rpc::{ClientPluginInfo, Location};
 use plugins::Command;
 
 /// An interface to the frontend.
@@ -180,6 +180,16 @@ impl Client {
 
     pub fn show_hover(&self, view_id: ViewId, request_id: usize, result: String) {
         self.0.send_rpc_notification("show_hover", &json!(
+            {
+                "view_id": view_id,
+                "request_id": request_id,
+                "result": result
+            }
+        ))
+    }
+
+    pub fn handle_definition(&self, view_id: ViewId, request_id: usize, result: Vec<Location>) {
+        self.0.send_rpc_notification("handle_definition", &json!(
             {
                 "view_id": view_id,
                 "request_id": request_id,

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -75,6 +75,7 @@ pub(crate) enum SpecialEvent {
     Resize(Size),
     RequestLines(LineRange),
     RequestHover { request_id: usize, position: Option<Position> },
+    RequestDefinition { request_id: usize, position: Option<Position> },
 }
 
 pub(crate) enum EventDomain {
@@ -230,9 +231,11 @@ impl From<EditNotification> for EventDomain {
             ReplaceNext => BufferEvent::ReplaceNext.into(),
             ReplaceAll => BufferEvent::ReplaceAll.into(),
             SelectionForReplace => ViewEvent::SelectionForReplace.into(),
+            SelectionIntoLines => ViewEvent::SelectionIntoLines.into(),
             RequestHover { request_id, position } =>
                 SpecialEvent::RequestHover { request_id, position }.into(),
-            SelectionIntoLines => ViewEvent::SelectionIntoLines.into(),
+            RequestDefinition { request_id, position } =>
+                SpecialEvent::RequestDefinition { request_id, position }.into(),
         }
     }
 }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -138,7 +138,7 @@ impl<'a> EventContext<'a> {
             SpecialEvent::RequestLines(LineRange { first, last }) =>
                 self.do_request_lines(first as usize, last as usize),
             SpecialEvent::RequestHover{ request_id, position } =>
-                self.do_request_definition(request_id, position),
+                self.do_request_hover(request_id, position),
             SpecialEvent::RequestDefinition { request_id, position } =>
                 self.do_request_definition(request_id, position),
         }
@@ -456,7 +456,7 @@ impl<'a> EventContext<'a> {
     fn do_handle_definition(&mut self, request_id: usize, definition: Result<Vec<Location>, RemoteError>) {
         match definition {
             Ok(definition) => {
-
+                self.client.handle_definition(self.view_id, request_id, definition);
             },
             Err(err) => eprintln!("Definition Response error {:?}", err)
         }

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -134,6 +134,13 @@ impl Plugin {
                                                 "request_id": request_id,
                                                 "position": position}))
     }
+
+    pub fn get_definition(&self, view_id: ViewId, request_id: usize, position: usize) {
+        self.peer.send_rpc_notification("get_definition", 
+                                        &json!({"view_id": view_id,
+                                                "request_id": request_id,
+                                                "position": position}))
+    }
 }
 
 pub(crate) fn start_plugin_process(plugin_desc: Arc<PluginDescription>,

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -110,6 +110,7 @@ pub enum HostNotification {
     NewBuffer { buffer_info: Vec<PluginBufferInfo> },
     DidClose { view_id: ViewId },
     GetHover { view_id: ViewId, request_id: usize, position: usize },
+    GetDefinition { view_id: ViewId, request_id: usize, position: usize },
     Shutdown(EmptyStruct),
     TracingConfig {enabled: bool},
 }
@@ -187,12 +188,12 @@ pub enum PluginNotification {
     UpdateStatusItem { key: String, value: String  },
     RemoveStatusItem { key: String },
     ShowHover { request_id: usize, result: Result<Hover, RemoteError> },
+    HandleDefinition { request_id: usize, result: Result<Vec<Location>, RemoteError> }
 }
 
-/// Range expressed in terms of PluginPosition. Meant to be sent from
+/// Range expressed in terms of UTF-8 offsets. Meant to be sent from
 /// plugin to core.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
 pub struct Range {
     pub start: usize,
     pub end: usize,
@@ -200,10 +201,15 @@ pub struct Range {
 
 /// Hover Item sent from Plugin to Core
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
 pub struct Hover {
     pub content: String,
     pub range: Option<Range>
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Location {
+    pub file_uri: PathBuf,
+    pub range: Range
 }
 
 /// Common wrapper for plugin-originating RPCs.

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -453,8 +453,9 @@ pub enum EditNotification {
     ReplaceNext,
     ReplaceAll,
     SelectionForReplace,
-    RequestHover { request_id: usize, position: Option<Position> },
     SelectionIntoLines,
+    RequestHover { request_id: usize, position: Option<Position> },
+    RequestDefinition { request_id: usize, position: Option<Position> },
 }
 
 /// The edit related requests.

--- a/rust/lsp-lib/src/language_server_client.rs
+++ b/rust/lsp-lib/src/language_server_client.rs
@@ -296,6 +296,25 @@ impl LanguageServerClient {
         let params = Params::from(serde_json::to_value(text_document_position_params).unwrap());
         self.send_request("textDocument/hover", params, Box::new(on_result))
     }
+
+    pub fn request_definition<CB>(
+        &mut self,
+        view_id: ViewId,
+        position: Position,
+        on_result: CB,
+    ) where
+        CB: 'static + Send + FnOnce(&mut LanguageServerClient, Result<Value, Error>),
+    {
+        let text_document_position_params = TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: self.opened_documents.get(&view_id).unwrap().clone(),
+            },
+            position,
+        };
+
+        let params = Params::from(serde_json::to_value(text_document_position_params).unwrap());
+        self.send_request("textDocument/definition", params, Box::new(on_result))
+    }
 }
 
 /// Helper methods to query the capabilities of the Language Server before making

--- a/rust/lsp-lib/src/lsp_plugin.rs
+++ b/rust/lsp-lib/src/lsp_plugin.rs
@@ -14,21 +14,21 @@
 
 //! Implementation of Language Server Plugin
 
-use result_queue::ResultQueue;
 use conversion_utils::*;
 use language_server_client::LanguageServerClient;
 use lsp_types::*;
+use result_queue::ResultQueue;
 use serde_json;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
-use types::{Config, LspResponse, LanguageResponseError};
+use types::{Config, Definition, LanguageResponseError, LspResponse};
 use url::Url;
 use utils::*;
 use xi_core::ConfigTable;
 use xi_core::ViewId;
-use xi_plugin_lib::{ChunkCache, CoreProxy, Plugin, View};
+use xi_plugin_lib::{ChunkCache, CoreProxy, Plugin, PluginContext, View};
 use xi_rope::rope::RopeDelta;
 
 pub struct ViewInfo {
@@ -93,16 +93,15 @@ impl Plugin for LspPlugin {
         trace!("saved view {}", view.get_id());
 
         let document_text = view.get_document().unwrap();
-        self.with_language_server_for_view(view, |ls_client| {
+        self.with_language_server_for_view_id(view.get_id(), |ls_client| {
             ls_client.send_did_save(view.get_id(), document_text);
         });
     }
 
     fn did_close(&mut self, view: &View<Self::Cache>) {
         trace!("close view {}", view.get_id());
-        
-        self.with_language_server_for_view(view, |ls_client| {
-            ls_client.send_did_close(view.get_id());    
+        self.with_language_server_for_view_id(view.get_id(), |ls_client| {
+            ls_client.send_did_close(view.get_id());
         });
     }
 
@@ -164,60 +163,96 @@ impl Plugin for LspPlugin {
 
     fn config_changed(&mut self, _view: &mut View<Self::Cache>, _changes: &ConfigTable) {}
 
-    fn get_hover(
-        &mut self,
-        view: &mut View<Self::Cache>,
-        request_id: usize,
-        position: usize,
-    ) {
-
+    fn get_hover(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) {
         let view_id = view.get_id();
         let position_ls = get_position_of_offset(view, position);
 
-        self.with_language_server_for_view(view, |ls_client| {
+        self.with_language_server_for_view_id(view.get_id(), |ls_client| match position_ls {
+            Ok(position) => ls_client.request_hover(view_id, position, move |ls_client, result| {
+                let res = result
+                    .map_err(|e| LanguageResponseError::LanguageServerError(format!("{:?}", e)))
+                    .and_then(|h| {
+                        let hover: Option<Hover> = serde_json::from_value(h).unwrap();
+                        hover.ok_or(LanguageResponseError::NullResponse)
+                    });
 
-                match position_ls {
-                    Ok(position) => ls_client.request_hover(
-                        view_id,
-                        position,
-                        move |ls_client, result| {
-                            let res = result
-                                .map_err(|e| LanguageResponseError::LanguageServerError(format!("{:?}", e)))
-                                .and_then(|h| {
-                                    let hover: Option<Hover> = serde_json::from_value(h).unwrap();
-                                    hover.ok_or(LanguageResponseError::NullResponse)
-                                });
-                            
-                            ls_client.result_queue.push_result(request_id, LspResponse::Hover(res));
-                            ls_client.core.schedule_idle(view_id);
-                        },
-                    ),
-                    Err(err) => {
-                        ls_client.result_queue.push_result(request_id, LspResponse::Hover(Err(err.into())));
-                        ls_client.core.schedule_idle(view_id);
-                    }
-                }
-                    
+                ls_client
+                    .result_queue
+                    .push_result(request_id, LspResponse::Hover(res));
+                ls_client.core.schedule_idle(view_id);
+            }),
+            Err(err) => {
+                ls_client
+                    .result_queue
+                    .push_result(request_id, LspResponse::Hover(Err(err.into())));
+                ls_client.core.schedule_idle(view_id);
+            }
         });
     }
 
-    fn idle(&mut self, view: &mut View<Self::Cache>) {
+    fn get_definition(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) {
+        let view_id = view.get_id();
+        let position_ls = get_position_of_offset(view, position);
+
+        self.with_language_server_for_view_id(view.get_id(), |ls_client| match position_ls {
+            Ok(position) => ls_client.request_definition(view_id, position, move |ls_client, result| {
+                let res = result
+                    .map_err(|e| LanguageResponseError::LanguageServerError(format!("{:?}", e)))
+                    .and_then(|d| {
+                        let definition: Option<Definition> = serde_json::from_value(d).unwrap();
+                        definition.ok_or(LanguageResponseError::NullResponse)
+                    });
+
+                ls_client
+                    .result_queue
+                    .push_result(request_id, LspResponse::Definition(res));
+                ls_client.core.schedule_idle(view_id);
+            }),
+            Err(err) => {
+                ls_client
+                    .result_queue
+                    .push_result(request_id, LspResponse::Definition(Err(err.into())));
+                ls_client.core.schedule_idle(view_id);
+            }
+        });
+    }
+
+    fn idle(&mut self, view_id: ViewId, plugin_context: &mut PluginContext<Self::Cache>) {
         let result = self.result_queue.pop_result();
-        if let Some((request_id, reponse)) = result {
-            match reponse {
+        
+        if let Some((request_id, response)) = result {
+            match response {
                 LspResponse::Hover(res) => {
-                    let res = res.and_then(|h| core_hover_from_hover(view, h)).map_err(|e| e.into());
-                    self.with_language_server_for_view(view, |ls_client| 
-                            ls_client.core.display_hover(view.get_id(), request_id, res));
+                    let res = res
+                        .and_then(|h| core_hover_from_hover(plugin_context, h))
+                        .map_err(|e| e.into());
+                    self.with_language_server_for_view_id(view_id, |ls_client| {
+                        ls_client.core.display_hover(view_id, request_id, res)
+                    });
+                },
+                LspResponse::Definition(res) => {
+                    let res = res
+                        .and_then(|d| core_definition_from_definition(plugin_context, d))
+                        .map_err(|e| e.into());
+                    self.with_language_server_for_view_id(view_id, |ls_client| {
+                        ls_client.core.handle_definition(view_id, request_id, res)
+                    });
                 }
             }
         }
+
+        let prime_view = match plugin_context.get_view(&view_id) {
+            Some(view) => view,
+            None => {
+                eprintln!("View not found for id: {}", view_id);
+                return;
+            }
+        };
     }
 }
 
 /// Util Methods
 impl LspPlugin {
-
     /// Get the Language Server Client given the Workspace root
     /// This method checks if a language server is running at the specified root
     /// and returns it else it tries to spawn a new language server and returns a
@@ -302,16 +337,21 @@ impl LspPlugin {
             })
     }
 
-    fn with_language_server_for_view<F, R>(&mut self, view: &View<ChunkCache>, f: F) -> Option<R>
-        where F: FnOnce(&mut LanguageServerClient) -> R {     
-            let view_info = if let Some(view_info) = self.view_info.get_mut(&view.get_id()) {
-                view_info
-            } else {
-                return None;
-            };
+    fn with_language_server_for_view_id<F, R>(&mut self, view_id: ViewId, f: F) -> Option<R>
+    where
+        F: FnOnce(&mut LanguageServerClient) -> R,
+    {
+        let view_info = if let Some(view_info) = self.view_info.get_mut(&view_id) {
+            view_info
+        } else {
+            return None;
+        };
 
-            let ls_client_arc = self.language_server_clients.get(&view_info.ls_identifier).unwrap();
-            let mut ls_client = ls_client_arc.lock().unwrap();
-            Some(f(&mut ls_client))
+        let ls_client_arc = self
+            .language_server_clients
+            .get(&view_info.ls_identifier)
+            .unwrap();
+        let mut ls_client = ls_client_arc.lock().unwrap();
+        Some(f(&mut ls_client))
     }
 }

--- a/rust/lsp-lib/src/types.rs
+++ b/rust/lsp-lib/src/types.rs
@@ -132,6 +132,8 @@ impl From<IOError> for Error {
 pub enum LanguageResponseError {
     LanguageServerError(String),
     PluginLibError(PluginLibError),
+    IOError(IOError),
+    MiscError,
     NullResponse,
     FallbackResponse,
 }
@@ -139,6 +141,18 @@ pub enum LanguageResponseError {
 impl From<PluginLibError> for LanguageResponseError {
     fn from(error: PluginLibError) -> Self {
         LanguageResponseError::PluginLibError(error)
+    }
+}
+
+impl From<()> for LanguageResponseError {
+    fn from(_error: ()) -> Self {
+        LanguageResponseError::MiscError
+    }
+}
+
+impl From<IOError> for LanguageResponseError {
+    fn from(error: IOError) -> Self {
+        LanguageResponseError::IOError(error)
     }
 }
 
@@ -153,6 +167,10 @@ impl Into<RemoteError> for LanguageResponseError {
                     RemoteError::custom(2, "language server error occured", Some(Value::String(error))),
             LanguageResponseError::PluginLibError(error) =>
                     RemoteError::custom(3, "Plugin Lib Error", Some(Value::String(format!("{:?}",error)))),
+            LanguageResponseError::IOError(error) =>
+                    RemoteError::custom(4, "I/O Error", Some(Value::String(format!("{:?}",error)))),
+            LanguageResponseError::MiscError =>
+                    RemoteError::custom(5, "Unknown error occured", None),
         }
     }
 }

--- a/rust/lsp-lib/src/types.rs
+++ b/rust/lsp-lib/src/types.rs
@@ -157,7 +157,15 @@ impl Into<RemoteError> for LanguageResponseError {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum Definition {
+    Location(Location),
+    Locations(Vec<Location>),
+}
+
 #[derive(Debug)]
 pub enum LspResponse {
-    Hover(Result<Hover, LanguageResponseError>)
+    Hover(Result<Hover, LanguageResponseError>),
+    Definition(Result<Definition, LanguageResponseError>)
 }

--- a/rust/lsp-lib/src/utils.rs
+++ b/rust/lsp-lib/src/utils.rs
@@ -208,8 +208,6 @@ pub fn start_new_server(
 }
 
 /// Helper Method to get Url of the View path
-/// Panics: If view does not have a path or the given path
-/// can not be converted to Url
-pub fn get_view_uri<C: Cache>(view: &View<C>) -> Url {
-    Url::from_file_path(view.get_path().unwrap().clone()).expect("Can't convert View Path to Url")
+pub fn get_view_uri<C: Cache>(view: &View<C>) -> Option<Url> {
+    view.get_path().and_then(|p| Url::from_file_path(p).ok())
 }

--- a/rust/lsp-lib/src/utils.rs
+++ b/rust/lsp-lib/src/utils.rs
@@ -206,3 +206,10 @@ pub fn start_new_server(
 
     Ok(language_server_client)
 }
+
+/// Helper Method to get Url of the View path
+/// Panics: If view does not have a path or the given path
+/// can not be converted to Url
+pub fn get_view_uri<C: Cache>(view: &View<C>) -> Url {
+    Url::from_file_path(view.get_path().unwrap().clone()).expect("Can't convert View Path to Url")
+}

--- a/rust/plugin-lib/src/core_proxy.rs
+++ b/rust/plugin-lib/src/core_proxy.rs
@@ -14,9 +14,9 @@
 
 //! A proxy for the methods on Core
 use xi_core::internal::plugins::PluginId;
-use xi_core::plugin_rpc::Hover;
+use xi_core::plugin_rpc::{Hover, Location};
 use xi_core::ViewId;
-use xi_rpc::{RpcCtx, RpcPeer, RemoteError};
+use xi_rpc::{RemoteError, RpcCtx, RpcPeer};
 
 #[derive(Clone)]
 pub struct CoreProxy {
@@ -52,7 +52,8 @@ impl CoreProxy {
             "value": value
         });
 
-        self.peer.send_rpc_notification("update_status_item", &params)
+        self.peer
+            .send_rpc_notification("update_status_item", &params)
     }
 
     pub fn remove_status_item(&mut self, view_id: &ViewId, key: &str) {
@@ -62,14 +63,15 @@ impl CoreProxy {
             "key": key
         });
 
-        self.peer.send_rpc_notification("remove_status_item", &params)
+        self.peer
+            .send_rpc_notification("remove_status_item", &params)
     }
 
     pub fn display_hover(
         &mut self,
         view_id: ViewId,
         request_id: usize,
-        result: Result<Hover, RemoteError>
+        result: Result<Hover, RemoteError>,
     ) {
         let params = json!({
             "plugin_id": self.plugin_id,
@@ -79,6 +81,22 @@ impl CoreProxy {
         });
 
         self.peer.send_rpc_notification("show_hover", &params);
+    }
+
+    pub fn handle_definition(
+        &mut self,
+        view_id: ViewId,
+        request_id: usize,
+        result: Result<Vec<Location>, RemoteError>,
+    ) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "request_id": request_id,
+            "result": result,
+            "view_id": view_id
+        });
+
+        self.peer.send_rpc_notification("handle_definition", &params);
     }
 
     pub fn schedule_idle(&mut self, view_id: ViewId) {

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
 use Cache;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -53,24 +52,19 @@ macro_rules! bail_err {
 /// Handles raw RPCs from core, updating state and forwarding calls
 /// to the plugin,
 pub struct Dispatcher<'a, P: 'a + Plugin> {
-    //TODO: when we add multi-view, this should be an Arc+Mutex/Rc+RefCell
-    //views: HashMap<ViewId, View<P::Cache>>,
-    plugin_context: PluginContext<<P>::Cache>,
+    views: HashMap<ViewId, View<P::Cache>>,
     pid: Option<PluginPid>,
     plugin: &'a mut P,
 }
 
-pub struct PluginContext<C: Cache> {
-    views: HashMap<ViewId, View<C>>,
+/// Provides access to all active views.
+pub struct PluginContext<'a, C: 'a + Cache> {
+    //TODO: when we add multi-view, this should be an Arc+Mutex/Rc+RefCell
+    views: & 'a mut HashMap<ViewId, View<C>>,
 }
 
-impl<C: Cache> PluginContext<C> {
-    pub(crate) fn new() -> Self {
-        PluginContext {
-            views: HashMap::new()
-        }
-    }
-
+impl<'a, C: Cache> PluginContext<'a, C> {
+    
     pub fn with_view<F, R>(&mut self, view_id: &ViewId, f: F) -> Option<R> 
         where F: FnOnce(&mut View<C>) -> R {
         let view = self.views.get_mut(view_id);
@@ -102,7 +96,7 @@ impl<C: Cache> PluginContext<C> {
 impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
     pub (crate) fn new(plugin: &'a mut P) -> Self {
         Dispatcher {
-            plugin_context: PluginContext::new(),
+            views: HashMap::new(),
             pid: None,
             plugin: plugin,
         }
@@ -123,14 +117,14 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
     }
 
     fn do_did_save(&mut self, view_id: ViewId, path: PathBuf) {
-        let v = bail!(self.plugin_context.get_view(&view_id), "did_save", self.pid, view_id);
+        let v = bail!(self.views.get_mut(&view_id), "did_save", self.pid, view_id);
         let prev_path = v.path.take();
         v.path = Some(path);
         self.plugin.did_save(v, prev_path.as_ref().map(PathBuf::as_path));
     }
 
     fn do_config_changed(&mut self, view_id: ViewId, changes: ConfigTable) {
-        let v = bail!(self.plugin_context.get_view(&view_id), "config_changed", self.pid, view_id);
+        let v = bail!(self.views.get_mut(&view_id), "config_changed", self.pid, view_id);
         self.plugin.config_changed(v, &changes);
         for (key, value) in changes.iter() {
             v.config_table.insert(key.to_owned(), value.to_owned());
@@ -146,17 +140,17 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
             .for_each(|view| {
                 let mut view = view;
                 self.plugin.new_view(&mut view);
-                self.plugin_context.insert_view(view);
+                self.views.insert(view.get_id(), view);
             });
 
     }
 
     fn do_close(&mut self, view_id: ViewId) {
         {
-            let v = bail!(self.plugin_context.get_view(&view_id), "close", self.pid, view_id);
+            let v = bail!(self.views.get_mut(&view_id), "close", self.pid, view_id);
             self.plugin.did_close(v);
         }
-        self.plugin_context.remove_view(&view_id);
+        self.views.remove(&view_id);
     }
 
     fn do_shutdown(&mut self) {
@@ -166,12 +160,12 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
     }
 
     fn do_get_hover(&mut self, view_id: ViewId, request_id: usize, position: usize) {
-        let v = bail!(self.plugin_context.get_view(&view_id), "get_hover", self.pid, view_id);
+        let v = bail!(self.views.get_mut(&view_id), "get_hover", self.pid, view_id);
         self.plugin.get_hover(v, request_id, position)
     }
 
     fn do_get_definition(&mut self, view_id: ViewId, request_id: usize, position: usize) {
-        let v = bail!(self.plugin_context.get_view(&view_id), "get_definition", self.pid, view_id);
+        let v = bail!(self.views.get_mut(&view_id), "get_definition", self.pid, view_id);
         self.plugin.get_definition(v, request_id, position)
     }
 
@@ -194,7 +188,7 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         let PluginUpdate {
             view_id, delta, new_len, new_line_count, rev, undo_group, edit_type, author,
         } = update;
-        let v = bail_err!(self.plugin_context.get_view(&view_id), "update",
+        let v = bail_err!(self.views.get_mut(&view_id), "update",
                           self.pid, view_id);
         v.update(delta.as_ref(), new_len, new_line_count, rev, undo_group);
         self.plugin.update(v, delta.as_ref(), edit_type, author);
@@ -261,8 +255,10 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
         let _t = trace_block_payload("Dispatcher::idle", &["plugin"],
                                      format!("token: {}", token));
         let view_id: ViewId = token.into();
-        //let v = bail!(self.plugin_context.get_view(&view_id), "idle", self.pid, view_id);
-        self.plugin.idle(view_id, &mut self.plugin_context);
+        
+        let Dispatcher { ref mut views, .. } = self;
+        let mut ctx = PluginContext { views: views };
+        self.plugin.idle(view_id, &mut ctx);
     }
 }
 

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
 use Cache;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -86,6 +87,15 @@ impl<C: Cache> PluginContext<C> {
 
     pub fn remove_view(&mut self, view_id: &ViewId) {
         self.views.remove(view_id);
+    }
+
+    pub fn get_view_for_path(&mut self, path_buf: &PathBuf) -> Option<&mut View<C>> {
+        for view in self.views.values_mut() {
+            if view.get_path() == Some(path_buf.as_path()) {
+                return Some(view)
+            }
+        }
+        None
     }
 }
 

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -36,6 +36,7 @@ mod view;
 mod dispatch;
 mod core_proxy;
 
+use xi_core::ViewId;
 use std::io;
 use std::path::Path;
 
@@ -46,11 +47,13 @@ use xi_core::plugin_rpc::{GetDataResponse, TextUnit};
 
 use self::dispatch::Dispatcher;
 
+
+pub use dispatch::PluginContext;
 pub use view::View;
 pub use state_cache::StateCache;
 pub use base_cache::ChunkCache;
 pub use core_proxy::CoreProxy;
-pub use xi_core::plugin_rpc::{Hover, Range};
+pub use xi_core::plugin_rpc::{Hover, Location, Range};
 
 /// Abstracts getting data from the peer. Mainly exists for mocking in tests.
 pub trait DataSource {
@@ -150,12 +153,15 @@ pub trait Plugin {
     /// are doing things like full document analysis can use this mechanism
     /// to perform their work incrementally while remaining responsive.
     #[allow(unused_variables)]
-    fn idle(&mut self, view: &mut View<Self::Cache>) { }
+    fn idle(&mut self, view_id: ViewId, plugin_context: &mut PluginContext<Self::Cache>) { }
 
     /// Language Plugins specific methods
     
     #[allow(unused_variables)]
     fn get_hover(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) { }
+
+    #[allow(unused_variables)]
+    fn get_definition(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) { }
 }
 
 #[derive(Debug)]

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -33,7 +33,7 @@ use xi_rope::rope::RopeDelta;
 use xi_rope::interval::Interval;
 use xi_rope::delta::Builder as EditBuilder;
 use xi_trace::{trace, trace_block};
-use xi_plugin_lib::{Cache, Plugin, StateCache, View, mainloop};
+use xi_plugin_lib::{Cache, Plugin, PluginContext, StateCache, View, mainloop};
 
 use syntect::parsing::{ParseState, ScopeStack, SyntaxSet, SCOPE_REPO,
                        SyntaxDefinition, ScopeRepository};
@@ -333,7 +333,15 @@ impl<'a> Plugin for Syntect<'a> {
         }
     }
 
-    fn idle(&mut self, view: &mut View<Self::Cache>) {
+    fn idle(&mut self, view_id: ViewId, plugin_context: &mut PluginContext<Self::Cache>) {
+        let view = match plugin_context.get_view(&view_id) {
+            Some(view) => view,
+            None => {
+                eprintln!("View with ViewId {} not found", view_id);
+                return;
+            }
+        };
+
         let state = self.view_state.get_mut(&view.get_id()).unwrap();
         for _ in 0..LINES_PER_RPC {
             if !state.highlight_one_line(view) {


### PR DESCRIPTION
Fixes #719 

This adds definition support using Definition RPC of Language Server Protocol. Currently, it was to be triggered by `RequestDefinition` RPC by Client which then gets back the response in `HandleDefinition` request. The client is supposed to check if it wants to open a new file or move caret to the given offset in the same file, it can be done by checking the `file_uri` field of Location.

The value sent to client is a `Location[]`. As discussed in the issue, following behaviour is ideally expected.
- If Location is empty, show a message like "Definition not found"
- If size is 1, go to the location. It could be in the same view or other, `new_view` with Location offset rpc work was done by @cmyr sometimes ago in a PR right? 
- If multiple choices, the client can be given a dialog to choose from. 

cc: @nangtrongvuon 