### PR TITLE
Selection granularity for drag gestures

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -438,9 +438,9 @@ impl View {
             sel.add_region(SelRegion::new(last.start, offset));
             sel
         };
-        let min = sel.last().unwrap().start;
+        let range_start = sel.last().unwrap().start;
         self.set_selection(text, sel);
-        self.start_drag(offset, min, offset, SelectionGranularity::Point, false);
+        self.start_drag(range_start, range_start, range_start, SelectionGranularity::Point, false);
 }
 
     /// Selects the given region and supports multi selection.


### PR DESCRIPTION
Like most text editors, Xi lets you select a word by double-clicking or a line by triple-clicking. However, if you then drag the cursor, it will extend the selection one character at a time. This PR assigns the appropriate granularity to drag gestures, depending on whether they started with a single, double, or triple click.