### PR TITLE
Fix warning: function is never used: `split_as_leaves`

### DIFF
--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -696,6 +696,7 @@ impl TreeBuilder<RopeInfo> {
     }
 }
 
+#[cfg(test)]
 fn split_as_leaves(mut s: &str) -> Vec<String> {
     let mut nodes = Vec::new();
     while !s.is_empty() {


### PR DESCRIPTION
```
   --> rope/src/rope.rs:699:1
    |
699 | fn split_as_leaves(mut s: &str) -> Vec<String> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(dead_code)] on by default
```