### PR TITLE
Bugfix: Duplicate line will duplicate selected regions instead of lines

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -706,14 +706,12 @@ impl Editor {
 
         for (start, end) in to_duplicate {
             // insert duplicates
-            let duplicated_text = self.text.slice_to_string(start..end);
             let iv = Interval::new_closed_open(start, start);
+            builder.replace(iv, self.text.slice(start..end));
 
             // last line does not have new line character so it needs to be manually added
             if end == self.text.len() {
-                builder.replace(iv, Rope::from(duplicated_text + &config.line_ending))
-            } else {
-                builder.replace(iv, Rope::from(duplicated_text))
+                builder.replace(iv, Rope::from(&config.line_ending))
             }
         }
 


### PR DESCRIPTION
This is a fix for duplicating lines to get the same behaviour as in Sublime: If <kbd>cmd</kbd><kbd>shift</kbd><kbd>D</kbd> is pressed, then all lines that have a caret get duplicated. In case of selections, only the selection will get duplicated (not the entire line).