### PR TITLE
Fix RangeSelect behaviour 

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -431,9 +431,10 @@ impl View {
             sel.add_region(SelRegion::new(last.start, offset));
             sel
         };
+        let min = sel.last().unwrap().start;
         self.set_selection(text, sel);
-        self.start_drag(offset, offset, offset);
-    }
+        self.start_drag(offset, min, offset);
+}
 
     /// Selects the given region and supports multi selection.
     fn select_region(&mut self, text: &Rope, offset: usize, region: SelRegion, multi_select: bool) {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -419,22 +419,20 @@ impl View {
 
     /// Selects a specific range (eg. when the user performs SHIFT + click).
     pub fn select_range(&mut self, text: &Rope, offset: usize) {
-        if !self.is_point_in_selection(offset) {
-            let sel = {
-                let (last, rest) = self.sel_regions().split_last().unwrap();
-                let mut sel = Selection::new();
-                for &region in rest {
-                    sel.add_region(region);
-                }
-                // TODO: small nit, merged region should be backward if end < start.
-                // This could be done by explicitly overriding, or by tweaking the
-                // merge logic.
-                sel.add_region(SelRegion::new(last.start, offset));
-                sel
-            };
-            self.set_selection(text, sel);
-            self.start_drag(offset, offset, offset);
-        }
+        let sel = {
+            let (last, rest) = self.sel_regions().split_last().unwrap();
+            let mut sel = Selection::new();
+            for &region in rest {
+                sel.add_region(region);
+            }
+            // TODO: small nit, merged region should be backward if end < start.
+            // This could be done by explicitly overriding, or by tweaking the
+            // merge logic.
+            sel.add_region(SelRegion::new(last.start, offset));
+            sel
+        };
+        self.set_selection(text, sel);
+        self.start_drag(offset, offset, offset);
     }
 
     /// Selects the given region and supports multi selection.


### PR DESCRIPTION
This correct #810 and allow to drag a selection after a RangeSelect.

Before the fix, dragging after doing a RangeSelect would result in a new selection beginning at the end of the previous one. Now it correctly extend the selection. This is not perfect as the selection can only be shrinked to the original RangeSelect.