### PR TITLE
Fix protocol fronted.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ experimental GL-based front-end in Rust.
 
 There are notes (I wouldn’t call it
 documentation at this point) on the protocol at
-[frontend.md](http://google.github.io/xi-editor/docs/frontend-protocol.html). If you're working on a front-end, feel free to
+[frontend.md](https://xi-editor.github.io/xi-editor/docs/frontend-protocol.html). If you're working on a front-end, feel free to
 send a PR to add it to the above list.
 
 ## Design decisions


### PR DESCRIPTION
Trivial fix to reflect the fact the link is no longer on the google github org page.