### PR TITLE
Fix deprecated use of str::slice_unchecked in syntect-plugin.

### DIFF
--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -268,7 +268,7 @@ impl<'a> Syntect<'a> {
         let leading_ws = prev_line.char_indices()
             .find(|&(_, c)| !c.is_whitespace())
             .or(prev_line.char_indices().last())
-            .map(|(idx, _)| unsafe { prev_line.slice_unchecked(0, idx) })
+            .map(|(idx, _)| unsafe { prev_line.get_unchecked(0..idx) })
             .unwrap_or("");
 
         if self.increase_indentation(prev_line) {


### PR DESCRIPTION
As of Rust 1.29.0, `str::slice_unchecked` is deprecated and `str::get_unchecked` should be used instead. This PR fixes that.