### PR TITLE
Add license to diff test file

### DIFF
--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![feature(test)]
 
 extern crate test;


### PR DESCRIPTION
A license was missing in a recently added test file.
This PR adds it.