### PR TITLE
Add benchmark comparison to CI for pr builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ script:
   - export RUST_BACKTRACE=1
   - RUSTFLAGS="-D warnings" cargo check --all || exit
   - cargo test --all || exit
+
+after_success:
+  - cd rust
+  - ./travis-after-success.sh

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -268,7 +268,7 @@ impl<'a> Syntect<'a> {
         let leading_ws = prev_line.char_indices()
             .find(|&(_, c)| !c.is_whitespace())
             .or(prev_line.char_indices().last())
-            .map(|(idx, _)| unsafe { prev_line.slice_unchecked(0, idx) })
+            .map(|(idx, _)| unsafe { prev_line.get_unchecked(0..idx) })
             .unwrap_or("");
 
         if self.increase_indentation(prev_line) {

--- a/rust/travis_after_succes
+++ b/rust/travis_after_succes
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Script to compare benches in Travis CI
+# Inspiration and most of the code taken from https://sunjay.ca/2017/04/27/rust-benchmark-comparison-travis
+
+set -e
+set -x
+
+# The Travis environment variables behave like so:
+# TRAVIS_BRANCH
+#   - if PR build, this is the pr base branch
+#   - if push build, this is the branch that was pushed
+# TRAVIS_PULL_REQUEST_BRANCH
+#   - if PR build, this is the "target" of the pr, i.e. not the base branch
+#   - if push build, this is blank
+#
+# Example:
+# You open a PR with base `master`, and PR branch `foo`
+# During a PR build:
+#     TRAVIS_BRANCH=master
+#     TRAVIS_PULL_REQUEST_BRANCH=foo
+# During a push build:
+#     TRAVIS_BRANCH=foo
+#     TRAVIS_PULL_REQUEST_BRANCH=
+
+
+# Make sure it is a PR build and we are running nightly
+if [ -z "$TRAVIS_PULL_REQUEST_BRANCH" ] || ["$TRAVIS_RUST_VERSION" != "nightly"]; then
+    exit
+fi
+
+REMOTE_URL="$(git config --get remote.origin.url)"
+
+# Clone the repository fresh..for some reason checking out master fails
+# from a normal PR build's provided directory
+cd ${TRAVIS_BUILD_DIR}/..
+git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench"
+cd  "${TRAVIS_REPO_SLUG}-bench"
+
+cargo install cargo-benchcmp || true
+
+# Bench PR target
+git checkout -f "$TRAVIS_BRANCH"
+cargo bench --all --verbose | tee previous-benchmark
+
+# Bench PR source
+git checkout -f "$TRAVIS_PULL_REQUEST_BRANCH"
+cargo bench --all --verbose | tee current-benchmark
+
+# Compare
+cargo benchcmp previous-benchmark current-benchmark


### PR DESCRIPTION
Adds benchmark comparisons to the CI for PR builds of travis CI.
Powered by https://github.com/BurntSushi/cargo-benchcmp and inspired by [0](https://beachape.com/blog/2016/11/02/rust-performance-testing-on-travis-ci/) and [1](https://sunjay.ca/2017/04/27/rust-benchmark-comparison-travis).

Runs the benches of all crates in the workspace on the target and source branch of a PR. The output of these two runs are compared. Result of comparison can be found in the log of the CI build.

Since the benchmarking implementation in the `test` crate is not stable yet, these comparisons are only done for nightly