### PR TITLE
Fix unreachable_code warning on Windows

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -41,7 +41,10 @@ fn load_base_config() -> Table {
             let win_toml: &str = include_str!("../assets/windows.toml");
             return Some(load(win_toml))
         }
-        None
+        #[cfg(not(target_os = "windows"))]
+        {
+            None
+        }
     }
 
     let base_toml: &str = include_str!("../assets/defaults.toml");


### PR DESCRIPTION
We are having a platform specific override on Windows, which makes the "None" path unreachable. This throws a warning on Windows. Gate the non-windows path by a `cfg()` attribute to remove the warning.