### PR TITLE
remove `From` string impls from ViewId

### DIFF
--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -353,7 +353,7 @@ mod tests {
     fn test_de_plugin_rpc() {
         let json = r#"{"method": "alert", "params": {"view_id": "view-id-1", "plugin_id": 42, "msg": "ahhh!"}}"#;
         let de: PluginCommand<PluginNotification> = serde_json::from_str(json).unwrap();
-        assert_eq!(de.view_id, "view-id-1".into());
+        assert_eq!(de.view_id, ViewId(1));
         assert_eq!(de.plugin_id, PluginPid(42));
         match de.cmd {
             PluginNotification::Alert { ref msg } if msg == "ahhh!" => (),

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -117,7 +117,7 @@ pub enum CoreNotification {
     /// use xi_core::rpc::*;
     /// # fn main() {
     /// let edit = EditCommand {
-    ///     view_id: "view-id-1".into(),
+    ///     view_id: 1.into(),
     ///     cmd: EditNotification::Insert { chars: "hello!".into() },
     /// };
     /// let rpc = CoreNotification::Edit(edit);
@@ -157,7 +157,7 @@ pub enum CoreNotification {
     /// # fn main() {
     /// let rpc = CoreNotification::Plugin(
     ///     PluginNotification::Start {
-    ///         view_id: "view-id-1".into(),
+    ///         view_id: 1.into(),
     ///         plugin_name: "syntect".into(),
     ///     });
     ///


### PR DESCRIPTION
The deserializer should fail with an error, not panic, if the view id
does not have the expected format.

Fixes #832.