### PR TITLE
Make line endings stable during tests

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -36,13 +36,15 @@ fn load_base_config() -> Table {
     }
 
     fn platform_overrides() -> Option<Table> {
-        #[cfg(target_os = "windows")]
-        {
-            let win_toml: &str = include_str!("../assets/windows.toml");
-            return Some(load(win_toml))
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
+        if cfg!(test) {
+            // Exit early if we are in tests and never have platform overrides.
+            // This makes sure we have a stable test environment.
+            None
+        } else if cfg!(windows) {
+            let toml = include_str!("../assets/windows.toml");
+            Some(load(toml))
+        } else {
+            // All other platorms
             None
         }
     }


### PR DESCRIPTION
When running tests on Windows, we default to Windows line endings.
The tests however expect UNIX-style line endings. Let's override the
config during tests to ensure we always get unix style line endings.