### PR TITLE
Remove 'internal' submodule (temporarily)

### DIFF
--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -64,66 +64,34 @@ mod ledger_includes {
 #[cfg(feature = "ledger")]
 use ledger_includes::*;
 
-/// Internal data structures and logic.
-///
-/// These internals are not part of the public API (for the purpose of binding to
-/// a front-end), but are exposed here, largely so they appear in documentation.
-#[path=""]
-pub mod internal {
-    pub mod client;
-    pub mod core;
-    pub mod tabs;
-    pub mod editor;
-    pub mod edit_types;
-    pub mod event_context;
-    pub mod file;
-    pub mod find;
-    pub mod view;
-    pub mod linewrap;
-    pub mod plugins;
-    #[cfg(feature = "ledger")]
-    pub mod fuchsia;
-    pub mod styles;
-    pub mod word_boundaries;
-    pub mod index_set;
-    pub mod selection;
-    pub mod movement;
-    pub mod syntax;
-    pub mod layers;
-    pub mod config;
-    #[cfg(feature = "notify")]
-    pub mod watcher;
-    pub mod line_cache_shadow;
-    pub mod width_cache;
-}
+pub mod client;
+pub mod core;
+pub mod tabs;
+pub mod editor;
+pub mod edit_types;
+pub mod event_context;
+pub mod file;
+pub mod find;
+pub mod view;
+pub mod linewrap;
+pub mod plugins;
+#[cfg(feature = "ledger")]
+pub mod fuchsia;
+pub mod styles;
+pub mod word_boundaries;
+pub mod index_set;
+pub mod selection;
+pub mod movement;
+pub mod syntax;
+pub mod layers;
+pub mod config;
+#[cfg(feature = "notify")]
+pub mod watcher;
+pub mod line_cache_shadow;
+pub mod width_cache;
 
 pub mod rpc;
 
-use internal::tabs;
-use internal::core;
-use internal::client;
-use internal::edit_types;
-use internal::editor;
-use internal::event_context;
-use internal::file;
-use internal::find;
-use internal::view;
-use internal::linewrap;
-use internal::plugins;
-use internal::styles;
-use internal::word_boundaries;
-use internal::index_set;
-use internal::selection;
-use internal::movement;
-use internal::syntax;
-use internal::layers;
-use internal::config;
-#[cfg(feature = "notify")]
-use internal::watcher;
-use internal::line_cache_shadow;
-use internal::width_cache;
-#[cfg(feature = "ledger")]
-use internal::fuchsia;
 
 #[cfg(feature = "ledger")]
 use apps_ledger_services_public::Ledger_Proxy;

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -35,9 +35,8 @@ use selection::{Affinity, Selection, SelRegion};
 use tabs::{ViewId, BufferId};
 use width_cache::WidthCache;
 use word_boundaries::WordCursor;
-use find::Find;
+use find::{Find, FindStatus};
 use linewrap;
-use internal::find::FindStatus;
 
 type StyleMap = RefCell<ThemeStyleMap>;
 

--- a/rust/plugin-lib/src/core_proxy.rs
+++ b/rust/plugin-lib/src/core_proxy.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! A proxy for the methods on Core
-use xi_core::internal::plugins::PluginId;
+use xi_core::plugins::PluginId;
 use xi_core::plugin_rpc::Hover;
 use xi_core::ViewId;
 use xi_rpc::{RpcCtx, RpcPeer, RemoteError};


### PR DESCRIPTION
This was preventing rustfmt from running correctly on stable, which is blocking #846.