### PR TITLE
Make`slice_to_string` return `Cow<str>` instead of `String`

### DIFF
--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -160,13 +160,13 @@ impl Find {
     }
 
     /// Set search parameters and executes the search.
-    pub fn do_find(&mut self, text: &Rope, search_string: String, case_sensitive: bool,
+    pub fn do_find(&mut self, text: &Rope, search_string: &str, case_sensitive: bool,
                    is_regex: bool, whole_words: bool) {
         if search_string.len() == 0 {
             self.unset();
         }
 
-        self.set_find(&search_string, case_sensitive, is_regex, whole_words);
+        self.set_find(search_string, case_sensitive, is_regex, whole_words);
         self.update_find(text, 0, text.len(), false);
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -981,7 +981,7 @@ impl View {
             self.find.push(Find::new());
         }
 
-        self.find.first_mut().unwrap().do_find(text, search_query, case_sensitive, false, true);
+        self.find.first_mut().unwrap().do_find(text, &search_query, case_sensitive, false, true);
     }
 
     pub fn do_find(&mut self, text: &Rope, chars: String, case_sensitive: bool, is_regex: bool,
@@ -996,7 +996,7 @@ impl View {
             self.find.push(Find::new());
         }
 
-        self.find.first_mut().unwrap().do_find(text, chars, case_sensitive, is_regex, whole_words);
+        self.find.first_mut().unwrap().do_find(text, &chars, case_sensitive, is_regex, whole_words);
     }
 
     /// Selects the next find match.
@@ -1085,7 +1085,7 @@ impl View {
         };
 
         self.set_dirty(text);
-        self.do_set_replace(replacement, false);
+        self.do_set_replace(replacement.as_ref().to_owned(), false);
     }
 
     /// Get the line range of a selected region.

--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -433,7 +433,7 @@ mod tests {
             if offset > self.0.len() {
                 Err(Error::Other("offset too big".into()))
             } else {
-                let chunk = self.0.slice_to_string(offset..end_off);
+                let chunk = self.0.slice_to_string(offset..end_off).as_ref().to_owned();
                 Ok(GetDataResponse { chunk, offset, first_line, first_line_offset })
             }
         }


### PR DESCRIPTION
Make `slice_to_string` return `Cow<str>` instead of `String`. This avoids making a copy of the string on every call, even if the string is never modified. 

This is my first contribution to a Rust open source project, I hope my code is acceptable how it is

If not, I'm open for suggestions to improve or fix it.