### PR TITLE
put plugin_rpc back

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -702,7 +702,7 @@ impl Editor {
 
                 if start < end {
                     let interval = Interval::new_closed_open(start, end);
-                    let word = self.text.slice_to_string(start..end);
+                    let word = self.text.slice_to_cow(start..end);
 
                     // first letter is uppercase, remaining letters are lowercase
                     let (first_char, rest) = word.split_at(1);

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -134,6 +134,13 @@ impl Plugin {
                                                 "request_id": request_id,
                                                 "position": position}))
     }
+
+    pub fn dispatch_command(&self, view_id: ViewId, method: &str, params: &Value) {
+        self.peer.send_rpc_notification("custom_command", 
+                                        &json!({"view_id": view_id,
+                                                "method": method,
+                                                "params": params}))
+    }
 }
 
 pub(crate) fn start_plugin_process(plugin_desc: Arc<PluginDescription>,

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -311,8 +311,9 @@ impl CoreState {
                         self.do_start_plugin(view_id, &plugin_name),
                     PN::Stop { view_id, plugin_name } =>
                         self.do_stop_plugin(view_id, &plugin_name),
-                    PN::PluginRpc { .. } => ()
-                        //TODO: rethink custom plugin RPCs
+                    PN::PluginRpc { view_id, receiver, rpc } =>
+-                        //TODO: rethink custom plugin RPCs
+                        self.do_plugin_rpc(view_id, &receiver, &rpc.method, &rpc.params),
                 }
             TracingConfig { enabled } =>
                 self.toggle_tracing(enabled),
@@ -520,6 +521,12 @@ impl CoreState {
                 p.shutdown();
                 self.after_stop_plugin(&p);
             }
+    }
+
+    fn do_plugin_rpc(&self, view_id: ViewId, receiver: &str, method: &str, params: &Value) {
+        self.running_plugins.iter()
+            .filter(|p| p.name == receiver)
+            .for_each(|p| p.dispatch_command(view_id, method, params))
     }
 
     fn after_stop_plugin(&mut self, plugin: &Plugin) {

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -312,7 +312,6 @@ impl CoreState {
                     PN::Stop { view_id, plugin_name } =>
                         self.do_stop_plugin(view_id, &plugin_name),
                     PN::PluginRpc { view_id, receiver, rpc } =>
--                        //TODO: rethink custom plugin RPCs
                         self.do_plugin_rpc(view_id, &receiver, &rpc.method, &rpc.params),
                 }
             TracingConfig { enabled } =>


### PR DESCRIPTION
Can we re-enable plugin_rpc to how it was previously? 