### PR TITLE
#863 core should send client a list of available languages on startup

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -534,6 +534,11 @@ instance.
 
 Notifies the client of the available themes.
 
+#### available_languages
+
+`available_languages {"languages": ["Rust"]}`
+
+Notifies the client of the available languages.
 
 #### config_changed
 

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -24,6 +24,7 @@ use config::Table;
 use styles::ThemeSettings;
 use plugins::rpc::ClientPluginInfo;
 use plugins::Command;
+use syntax::LanguageId;
 
 /// An interface to the frontend.
 pub struct Client(RpcPeer);
@@ -69,6 +70,11 @@ impl Client {
     pub fn available_themes(&self, theme_names: Vec<String>) {
         self.0.send_rpc_notification("available_themes",
                                      &json!({"themes": theme_names}))
+    }
+
+    pub fn available_languages(&self, languages: Vec<LanguageId>) {
+        self.0.send_rpc_notification("available_languages",
+                                     &json!({"languages": languages}))
     }
 
     pub fn theme_changed(&self, name: &str, theme: &ThemeSettings) {

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -41,7 +41,7 @@ pub struct LanguageDefinition {
 /// A repository of all loaded `LanguageDefinition`s.
 #[derive(Debug, Default)]
 pub struct Languages {
-    named: HashMap<LanguageId, Arc<LanguageDefinition>>,
+    pub named: HashMap<LanguageId, Arc<LanguageDefinition>>,
     extensions: HashMap<String, Arc<LanguageDefinition>>,
 }
 

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -41,7 +41,7 @@ pub struct LanguageDefinition {
 /// A repository of all loaded `LanguageDefinition`s.
 #[derive(Debug, Default)]
 pub struct Languages {
-    pub named: HashMap<LanguageId, Arc<LanguageDefinition>>,
+    named: HashMap<LanguageId, Arc<LanguageDefinition>>,
     extensions: HashMap<String, Arc<LanguageDefinition>>,
 }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -194,6 +194,8 @@ impl CoreState {
         let plugin_paths = self.config_manager.get_plugin_paths();
         self.plugins.reload_from_paths(&plugin_paths);
         let languages = self.plugins.make_languages_map();
+        let languages_ids = languages.named.keys().cloned().collect::<Vec<_>>();
+        self.peer.available_languages(languages_ids);
         self.config_manager.set_languages(languages);
         let theme_names = self.style_map.borrow().get_theme_names();
         self.peer.available_themes(theme_names);

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -195,7 +195,7 @@ impl CoreState {
         let plugin_paths = self.config_manager.get_plugin_paths();
         self.plugins.reload_from_paths(&plugin_paths);
         let languages = self.plugins.make_languages_map();
-        let languages_ids = languages.named.keys().cloned().collect::<Vec<_>>();
+        let languages_ids = languages.iter().map(|l| l.name.clone()).collect::<Vec<_>>();
         self.peer.available_languages(languages_ids);
         self.config_manager.set_languages(languages);
         let theme_names = self.style_map.borrow().get_theme_names();

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -35,6 +35,7 @@ fn test_startup() {
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
     rx.expect_rpc("available_themes");
+    rx.expect_rpc("available_languages");
     rx.expect_rpc("theme_changed");
 
     let json = make_reader(r#"{"id":0,"method":"new_view","params":{}}"#);
@@ -176,6 +177,7 @@ fn test_settings_commands() {
 {"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
     rx.expect_rpc("available_themes");
+    rx.expect_rpc("available_languages");
     rx.expect_rpc("theme_changed");
     rx.expect_response().unwrap();
     rx.expect_rpc("available_plugins");

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -34,8 +34,8 @@ fn test_startup() {
     let json = make_reader(r#"{"method":"client_started","params":{}}
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    rx.expect_rpc("available_themes");
     rx.expect_rpc("available_languages");
+    rx.expect_rpc("available_themes");
     rx.expect_rpc("theme_changed");
 
     let json = make_reader(r#"{"id":0,"method":"new_view","params":{}}"#);
@@ -176,8 +176,8 @@ fn test_settings_commands() {
 {"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
 {"id":0,"method":"new_view","params":{}}"#);
     assert!(rpc_looper.mainloop(|| json, &mut state).is_ok());
-    rx.expect_rpc("available_themes");
     rx.expect_rpc("available_languages");
+    rx.expect_rpc("available_themes");
     rx.expect_rpc("theme_changed");
     rx.expect_response().unwrap();
     rx.expect_rpc("available_plugins");


### PR DESCRIPTION
#863 

Added the implementation of available languages.

Things to note:
Not quite sure if line 197 in tabs.rs is a good solution, would love to receive some feedback about it.