### PR TITLE
#866 allow client to override a buffer's language

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -73,13 +73,13 @@ note for `new_view`. Errors are not currently reported.
 
 `set_theme {"theme_name": "InspiredGitHub"}`
 
-Requests that core changes the theme. If the change succeeds the client
+Asks core to change the theme. If the change succeeds the client
 will receive a `theme_changed` notification.
 
 ### set_language
 `set_language {"view-id":"view-id-1", "language_id":"Rust"}`
 
-Requests that core changes the language of the buffer associated with the `view_id`.
+Asks core to change the language of the buffer associated with the `view_id`.
 
 ### modify_user_config
 

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -73,8 +73,13 @@ note for `new_view`. Errors are not currently reported.
 
 `set_theme {"theme_name": "InspiredGitHub"}`
 
-Requests that core change the theme. If the change succeeds the client
+Requests that core changes the theme. If the change succeeds the client
 will receive a `theme_changed` notification.
+
+### set_language
+`set_language {"view-id":"view-id-1", "language_id":"Rust"}`
+
+Requests that core changes the language of the buffer associated with the `view_id`.
 
 ### modify_user_config
 
@@ -117,13 +122,13 @@ multiple cursors and `chars` has the same number of lines as there are
 cursors, one line will be inserted at each cursor, in order; otherwise the full
 string will be inserted at each cursor.
 
-#### copy 
+#### copy
 
 `copy -> String|Null`
 
 Copies the active selection, returning their contents or `Null` if the selection was empty.
 
-#### cut 
+#### cut
 
 `cut -> String|Null`
 

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -29,6 +29,7 @@ use config::{Table, ConfigDomainExternal};
 use plugins::PlaceholderRpc;
 use tabs::ViewId;
 use view::Size;
+use syntax::LanguageId;
 
 // =============================================================================
 //  Command types
@@ -204,7 +205,9 @@ pub enum CoreNotification {
     TracingConfig {enabled: bool},
     /// Save trace data to the given path.  The core will first send
     /// CoreRequest::CollectTrace to all peers to collect the samples.
-    SaveTrace { destination: PathBuf, frontend_samples: Value }
+    SaveTrace { destination: PathBuf, frontend_samples: Value },
+    /// Tells `xi-core` to set the language id for the view.
+    SetLanguage { view_id: ViewId, language_id: LanguageId }
 }
 
 /// The requests which make up the base of the protocol.

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -48,6 +48,7 @@ use rpc::{CoreNotification, CoreRequest, EditNotification, EditRequest,
 use styles::{ThemeStyleMap, DEFAULT_THEME};
 use view::View;
 use width_cache::WidthCache;
+use syntax::LanguageId;
 
 #[cfg(feature = "notify")]
 use watcher::{FileWatcher, WatchToken};
@@ -318,6 +319,7 @@ impl CoreState {
                 self.toggle_tracing(enabled),
             // handled at the top level
             ClientStarted { .. } => (),
+            SetLanguage { view_id, language_id } => self.do_set_language(view_id, language_id),
         }
     }
 
@@ -435,7 +437,7 @@ impl CoreState {
     }
 
     fn do_set_theme(&self, theme_name: &str) {
-        //Set only if requested theme is different from the 
+        //Set only if requested theme is different from the
         //current one.
         if theme_name != self.style_map.borrow().get_theme_name() {
            if let Err(e) = self.style_map.borrow_mut().set_theme(&theme_name) {
@@ -530,6 +532,13 @@ impl CoreState {
 
     fn after_stop_plugin(&mut self, plugin: &Plugin) {
         self.iter_groups().for_each(|mut cx| cx.plugin_stopped(plugin));
+    }
+
+    fn do_set_language(&mut self, view_id: ViewId, language_id: LanguageId) {
+        if let Some(view) = self.views.get(&view_id) {
+            let buffer_id = view.borrow().get_buffer_id();
+            self.config_manager.override_language(buffer_id, language_id);
+        }
     }
 }
 
@@ -673,7 +682,7 @@ impl CoreState {
                     .get_theme_name()
                 {
                     if self.style_map.borrow_mut()
-                        .set_theme(&theme_name).is_ok() 
+                        .set_theme(&theme_name).is_ok()
                     {
                         self.notify_client_and_update_views();
                     }
@@ -686,7 +695,7 @@ impl CoreState {
     fn remove_theme(&mut self, path: &Path) {
         let result = self.style_map.borrow_mut().remove_theme(path);
 
-        // Set default theme if the removed theme was the 
+        // Set default theme if the removed theme was the
         // current one.
         if let Some(theme_name) = result {
             if theme_name == self.style_map.borrow().get_theme_name() {


### PR DESCRIPTION
I've added `set_language`, but haven't added tests yet since I haven't figured out the correct way to do it and it doesn't seem that all of the rpc commands are tested.

My editor removed some trailing whitespace, if that makes the diff noisy I can fix it.