### PR TITLE
Fixed some minor linting warnings as suggested by rust-clippy.

### DIFF
--- a/rust/rope/src/find.rs
+++ b/rust/rope/src/find.rs
@@ -165,9 +165,8 @@ fn find_core(cursor: &mut Cursor<RopeInfo>, lines: &mut LinesRaw, pat: &str,
         if let Some(off) = scanner(&leaf[pos_in_leaf..]) {
             let candidate_pos = orig_pos + off;
             cursor.set(candidate_pos);
-            match matcher(cursor, lines, pat) {
-                Some(actual_pos) => return FindResult::Found(actual_pos),
-                _ => ()
+            if let Some(actual_pos) = matcher(cursor, lines, pat) {
+                return FindResult::Found(actual_pos)
             }
         } else {
             let _ = cursor.next_leaf();
@@ -273,11 +272,11 @@ fn compare_cursor_regex(cursor: &mut Cursor<RopeInfo>, lines: &mut LinesRaw, pat
             let end_position = orig_position + mat.end();
             cursor.set(end_position);
 
-            return Some(start_position)
+            Some(start_position)
         },
         None => {
             cursor.set(orig_position + text.len());
-            return None
+            None
         }
     }
 }

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -591,7 +591,7 @@ impl Rope {
 
         ChunkIter {
             cursor: Cursor::new(self, start),
-            end: end,
+            end,
         }
     }
 
@@ -742,8 +742,7 @@ fn split_as_leaves(mut s: &str) -> Vec<String> {
         nodes.push(s[..splitpoint].to_owned());
         s = &s[splitpoint..];
     }
-
-    return nodes;
+    nodes
 }
 
 impl<T: AsRef<str>> From<T> for Rope {

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -300,11 +300,11 @@ impl<T: Clone + Default> Spans<T> {
     pub fn apply_shape<M: NodeInfo>(&mut self, delta: &Delta<M>) {
         let mut b = TreeBuilder::new();
         for elem in &delta.els {
-            match elem {
-                &DeltaElement::Copy(beg, end) =>
-                    b.push(self.subseq(Interval::new_closed_open(beg, end))),
-                &DeltaElement::Insert(ref n) =>
-                    b.push(SpansBuilder::new(n.len()).build()),
+            match *elem {
+                DeltaElement::Copy(beg, end) =>
+                   b.push(self.subseq(Interval::new_closed_open(beg, end))),
+                DeltaElement::Insert(ref n) =>
+                   b.push(SpansBuilder::new(n.len()).build()),
             }
         }
         *self = b.build();

--- a/rust/trace/src/lib.rs
+++ b/rust/trace/src/lib.rs
@@ -144,7 +144,7 @@ impl<'de> serde::Deserialize<'de> for CategoriesT {
             fn visit_str<E>(self, v: &str) -> Result<CategoriesT, E>
                 where E: serde::de::Error
             {
-                let categories = v.split(",").map(|s| s.to_string()).collect();
+                let categories = v.split(',').map(|s| s.to_string()).collect();
                 Ok(CategoriesT::DynamicArray(categories))
             }
         }


### PR DESCRIPTION
-Unneeded return statement in rope/src/find.rs lines 276 and 280
-Unneeded return statement in rope/src/rope.rs line 746
-Single character string constant used as pattern trace/src/lib.rs line 147
-Redundant field names in rope/src/rope.rs line 594
-Unnecessary & rather than dereference in rope/src/spans.rs line 594
-Unnecessary match in rope/src/find.rs line 168