### PR TITLE
Adding functionality to change the default logging directory.

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,5 +1,6 @@
 */Cargo.lock
 !/syntect-plugin/Cargo.lock
+/syntect-plugin/out
 *.rs.bk
 target
 build

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -105,6 +105,12 @@ fn generate_logging_path(logfile_config: LogfileConfig) -> Result<PathBuf, io::E
         Some(file_name) => file_name,
         None => PathBuf::from(XI_LOG_FILE),
     };
+    if logfile_file_name.eq(Path::new("")) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "A blank file name was supplied",
+        ));
+    };
     // Use the directory name set in logfile_config or fallback to the default
     let logfile_directory_name = match logfile_config.directory {
         Some(dir) => dir,
@@ -208,7 +214,7 @@ fn main() {
         );
     }
     if let Some(e) = logging_error {
-        warn!("Unable to successfully generate the logging path: {:?}", e)
+        warn!("Unable to successfully generate the logging path: {}", e)
     }
 
     match rpc_looper.mainloop(|| stdin.lock(), &mut state) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -39,12 +39,10 @@ fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, i
             log_dir.push(directory);
             Ok(log_dir)
         }
-        None => Err(
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "No standard logging directory known for this platform",
-            )
-        ),
+        None => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "No standard logging directory known for this platform",
+        )),
     }
 }
 
@@ -73,14 +71,13 @@ fn setup_logging(logging_path_result: Result<PathBuf, io::Error>) -> Result<(), 
 
     if let Ok(logging_file_path) = &logging_path_result {
         // Ensure the logging directory is created
-        let parent_path = logging_file_path.parent().ok_or(
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "Unable to get the parent of the following Path: {}", logging_file_path.display(),
-                )
-            )
-        )?;
+        let parent_path = logging_file_path.parent().ok_or(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Unable to get the parent of the following Path: {}",
+                logging_file_path.display(),
+            ),
+        ))?;
         fs::create_dir_all(parent_path)?;
         // Attach it to fern
         fern_dispatch = fern_dispatch.chain(fern::log_file(logging_file_path)?);
@@ -98,7 +95,10 @@ fn setup_logging(logging_path_result: Result<PathBuf, io::Error>) -> Result<(), 
             warn!("{}: {:?}, falling back to stderr.", message, e);
         }
         Ok(logging_file_path) => {
-            info!("Logging to the following file: {}", logging_file_path.display());
+            info!(
+                "Logging to the following file: {}",
+                logging_file_path.display()
+            );
         }
     }
     Ok(())
@@ -139,7 +139,9 @@ fn get_flags() -> HashMap<String, Option<String>> {
 
             // Check the next argument doesn't start with the flag prefix
             // map_or accounts for peek returning an Option
-            let next_arg_not_a_flag: bool = args_itterator.peek().map_or(false, |val| !val.starts_with(flag_prefix));
+            let next_arg_not_a_flag: bool = args_itterator
+                .peek()
+                .map_or(false, |val| !val.starts_with(flag_prefix));
             if next_arg_not_a_flag {
                 flags.insert(key, args_itterator.next());
             }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -62,19 +62,19 @@ fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, i
 /// use std::path::PathBuf;
 /// let path_with_file = PathBuf::from("/some/directory/then/file");
 /// assert_eq!(Some(OsStr::new("file")), path_with_file.file_name());
-/// assert_eq!(create_parent_directory(path_with_file).is_ok(), true);
+/// assert_eq!(create_log_directory(path_with_file).is_ok(), true);
 ///
 /// let path_with_other_file = PathBuf::from("/other_file");
 /// assert_eq!(Some(OsStr::new("other_file")), path_with_other_file.file_name());
-/// assert_eq!(create_parent_directory(path_with_file).is_ok(), true);
+/// assert_eq!(create_log_directory(path_with_file).is_ok(), true);
 ///
 /// // Path that is just the root or prefix:
 /// let path_without_file = PathBuf::from("/");
 /// assert_eq!(None, path_with_file.file_name());
-/// assert_eq!(create_parent_directory(path_with_file).is_ok(), false);
+/// assert_eq!(create_log_directory(path_with_file).is_ok(), false);
 /// ```
-pub fn create_parent_directory(path_with_file: &PathBuf) -> Result<(), io::Error> {
-    let parent_path = path_with_file.parent().ok_or(io::Error::new(
+fn create_log_directory(path_with_file: &PathBuf) -> Result<(), io::Error> {
+    let log_dir = path_with_file.parent().ok_or(io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(
             "Unable to get the parent of the following Path: {}",
@@ -82,7 +82,7 @@ pub fn create_parent_directory(path_with_file: &PathBuf) -> Result<(), io::Error
         ),
     ))?;
     // Try to create the directory.
-    fs::create_dir_all(parent_path)?;
+    fs::create_dir_all(log_dir)?;
     Ok(())
 }
 
@@ -111,7 +111,7 @@ fn setup_logging(logging_path_result: Option<PathBuf>) -> Result<(), fern::InitE
 
     if let Some(logging_file_path) = &logging_path_result {
         // Try to create the parent directories for the logging file in the logging file path
-        create_parent_directory(&logging_file_path)?;
+        create_log_directory(&logging_file_path)?;
 
         // Attach it to fern
         fern_dispatch = fern_dispatch.chain(fern::log_file(logging_file_path)?);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -81,7 +81,6 @@ fn create_log_directory(path_with_file: &PathBuf) -> Result<(), io::Error> {
             path_with_file.display(),
         ),
     ))?;
-    // Try to create the directory.
     fs::create_dir_all(log_dir)?;
     Ok(())
 }
@@ -110,10 +109,8 @@ fn setup_logging(logging_path: Option<PathBuf>) -> Result<(), fern::InitError> {
         .chain(io::stderr());
 
     if let Some(logging_file_path) = &logging_path {
-        // Try to create the parent directories for the logging file in the logging file path
         create_log_directory(&logging_file_path)?;
 
-        // Attach it to fern
         fern_dispatch = fern_dispatch.chain(fern::log_file(logging_file_path)?);
     };
 
@@ -226,11 +223,11 @@ fn main() {
     let stdout = io::stdout();
     let mut rpc_looper = RpcLoop::new(stdout);
 
-    let flags: HashMap<String, Option<String>> = get_flags();
+    let flags = get_flags();
 
     let logfile_config = generate_logfile_config(&flags);
 
-    let logging_path_result: Result<PathBuf, io::Error> = generate_logging_path(logfile_config);
+    let logging_path_result = generate_logging_path(logfile_config);
 
     let mut logging_path: Option<PathBuf> = None;
     let mut logging_error: Option<io::Error> = None;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -102,6 +102,30 @@ fn setup_logging() -> Result<(), fern::InitError> {
     Ok(())
 }
 
+fn prepare_logging_path(logfile_config: LogfileConfig) -> Result<PathBuf, io::Error> {
+    // Use the file name set in logfile_config or fallback to the default
+    let logfile_file_name = match logfile_config.file {
+        Some(file_name) => file_name,
+        None => XI_LOG_FILE.to_string(),
+    };
+    // Use the directory name set in logfile_config or fallback to the default
+    let logfile_directory_name = match logfile_config.directory {
+        Some(dir) => dir,
+        None => XI_LOG_DIR.to_string(),
+    };
+
+    let mut logging_directory_path = get_logging_directory_path(logfile_directory_name)?;
+
+    // Add the file name & return the full path
+    logging_directory_path.push(logfile_file_name);
+    Ok(logging_directory_path)
+}
+
+struct LogfileConfig {
+    directory: Option<String>,
+    file: Option<String>,
+}
+
 fn get_flags() -> HashMap<String, Option<String>> {
     let mut flags: HashMap<String, Option<String>> = HashMap::new();
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -152,8 +152,13 @@ fn get_flags() -> HashMap<String, Option<String>> {
 
 fn generate_logfile_config(flags: HashMap<String, Option<String>>) -> LogfileConfig {
     // If the key is set, get the Option within
-    let log_dir_flag_option = flags.get("log-dir").cloned().unwrap_or(None);
-    let log_file_flag_option = flags.get("log-file").cloned().unwrap_or(None);
+    let log_dir_flag_option = std::env::var("XI_LOG_DIR")
+        .ok()
+        .or(flags.get("log-dir").cloned().unwrap_or(None));
+
+    let log_file_flag_option = std::env::var("XI_LOG_FILE")
+        .ok()
+        .or(flags.get("log-file").cloned().unwrap_or(None));
 
     LogfileConfig {
         directory: log_dir_flag_option,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -22,6 +22,7 @@ extern crate dirs;
 extern crate xi_core_lib;
 extern crate xi_rpc;
 
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -111,6 +112,26 @@ fn setup_logging() -> Result<(), fern::InitError> {
 
     info!("Logging with fern is setup");
     Ok(())
+}
+
+fn get_flags() -> HashMap<String, Option<String>> {
+    let mut flags: HashMap<String, Option<String>> = HashMap::new();
+
+    let flag_prefix = "-";
+    let mut args_itterator = std::env::args().peekable();
+    while let Some(arg) = args_itterator.next() {
+        if arg.starts_with(flag_prefix) {
+            let key = arg.trim_left_matches(flag_prefix).to_string();
+
+            // Check the next argument doesn't start with the flag prefix
+            // map_or accounts for peek returning an Option
+            let next_arg_not_a_flag: bool = args_itterator.peek().map_or(false, |val| !val.starts_with(flag_prefix));
+            if next_arg_not_a_flag {
+                flags.insert(key, args_itterator.next());
+            }
+        }
+    }
+    flags
 }
 
 fn main() {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -90,15 +90,15 @@ fn setup_logging(logging_path_result: Result<PathBuf, io::Error>) -> Result<(), 
     // Log details of the logging_file_path result using fern/log
     // Either logging the path fern is outputting to or the error from obtaining the path
     match &logging_path_result {
-        Err(e) => {
-            let message = "There was an issue getting the path for the log file";
-            warn!("{}: {:?}, falling back to stderr.", message, e);
-        }
         Ok(logging_file_path) => {
             info!(
                 "Logging to the following file: {}",
                 logging_file_path.display()
             );
+        }
+        Err(e) => {
+            let message = "There was an issue getting the path for the log file";
+            warn!("{}: {:?}, falling back to stderr.", message, e);
         }
     }
     Ok(())

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -152,6 +152,17 @@ fn main() {
     let stdout = io::stdout();
     let mut rpc_looper = RpcLoop::new(stdout);
 
+    let flags: HashMap<String, Option<String>> = get_flags();
+
+    // If the key is set, get the Option within
+    let log_dir_flag_option = flags.get("log-dir").cloned().unwrap_or(None);
+    let log_file_flag_option = flags.get("log-file").cloned().unwrap_or(None);
+
+    let logfile_config = LogfileConfig {
+        directory: log_dir_flag_option,
+        file: log_file_flag_option,
+    };
+
     if let Err(e) = setup_logging() {
         eprintln!(
             "[ERROR] setup_logging returned error, logging disabled: {:?}",

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -49,7 +49,7 @@ fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, i
 /// This function tries to create the parent directories for a file
 ///
 /// It wraps around the `parent()` function of `Path` which returns an `Option<&Path>` and
-/// `fs::create_dir_all` which returns an `io::Result<()`.
+/// `fs::create_dir_all` which returns an `io::Result<()>`.
 ///
 /// This allows you to use `?`/`try!()` to create the dir and you recive the additional custom error for when `parent()`
 /// returns nothing.
@@ -75,7 +75,7 @@ fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, i
 /// assert_eq!(None, path_without_file.file_name());
 /// assert_eq!(create_log_directory(path_without_file).is_ok(), false);
 /// ```
-fn create_log_directory(path_with_file: &Path) -> Result<(), io::Error> {
+fn create_log_directory(path_with_file: &Path) -> io::Result<()> {
     let log_dir = path_with_file.parent().ok_or(io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -88,17 +88,19 @@ fn setup_logging(logging_path_result: Result<PathBuf, io::Error>) -> Result<(), 
 
     // Start fern
     fern_dispatch.apply()?;
+    info!("Logging with fern is setup");
 
-    // Log details of the fern setup using fern/log
-    match &path_result {
+    // Log details of the logging_file_path result using fern/log
+    // Either logging the path fern is outputting to or the error from obtaining the path
+    match &logging_path_result {
         Err(e) => {
             let message = "There was an issue getting the path for the log file";
             warn!("{}: {:?}, falling back to stderr.", message, e);
         }
-        Ok(logging_file_path) => info!("Logging to the following file: {:?}", logging_file_path),
+        Ok(logging_file_path) => {
+            info!("Logging to the following file: {}", logging_file_path.display());
+        }
     }
-
-    info!("Logging with fern is setup");
     Ok(())
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,20 +33,6 @@ use xi_rpc::RpcLoop;
 const XI_LOG_DIR: &str = "xi-core";
 const XI_LOG_FILE: &str = "xi-core.log";
 
-fn get_logfile_directory_name() -> String {
-    match std::env::var("XI_LOG_DIR") {
-        Ok(name) => name,
-        Err(_) => String::from(XI_LOG_DIR),
-    }
-}
-
-fn get_logfile_file_name() -> String {
-    match std::env::var("XI_LOG_FILE") {
-        Ok(name) => name,
-        Err(_) => String::from(XI_LOG_FILE),
-    }
-}
-
 fn get_logging_directory<P: AsRef<Path>>(directory: P) -> Result<PathBuf, io::Error> {
     match dirs::data_local_dir() {
         Some(mut log_dir) => {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,21 +33,23 @@ use xi_rpc::RpcLoop;
 const XI_LOG_DIR: &str = "xi-core";
 const XI_LOG_FILE: &str = "xi-core.log";
 
-fn get_logging_directory<P: AsRef<Path>>(directory: P) -> Result<PathBuf, io::Error> {
+fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, io::Error> {
     match dirs::data_local_dir() {
         Some(mut log_dir) => {
             log_dir.push(directory);
             Ok(log_dir)
         }
-        None => Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "No standard logging directory known for this platform",
-        )),
+        None => Err(
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "No standard logging directory known for this platform",
+            )
+        ),
     }
 }
 
 fn path_for_log_file<P: AsRef<Path>>(filename: P) -> Result<PathBuf, io::Error> {
-    let mut logging_directory = get_logging_directory(get_logfile_directory_name())?;
+    let mut logging_directory = get_logging_directory_path(get_logfile_directory_name())?;
     // Create the logging directory
     fs::create_dir_all(&logging_directory)?;
     // Pushing the filename to the end

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -77,7 +77,7 @@ fn create_log_directory(path_with_file: &PathBuf) -> Result<(), io::Error> {
     let log_dir = path_with_file.parent().ok_or(io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(
-            "Unable to get the parent of the following Path: {}",
+            "Unable to get the parent of the following Path: {}, Your path should contain a file name",
             path_with_file.display(),
         ),
     ))?;
@@ -119,13 +119,13 @@ fn setup_logging(logging_path: Option<PathBuf>) -> Result<(), fern::InitError> {
 
     // Start fern
     fern_dispatch.apply()?;
-    info!("Logging with fern is setup");
+    info!("Logging with fern is set up");
 
     // Log details of the logging_file_path result using fern/log
     // Either logging the path fern is outputting to or the error from obtaining the path
     match &logging_path {
         Some(logging_file_path) => info!("Writing logs to: {}", logging_file_path.display()),
-        None => warn!("There was no path supplied for the log file, falling back to stderr."),
+        None => warn!("No path was supplied for the log file, not saving logs to disk, falling back to just stderr"),
     }
     Ok(())
 }
@@ -245,7 +245,10 @@ fn main() {
         );
     }
     if let Some(e) = logging_error {
-        warn!("Unable to successfully generate the logging path: {}", e)
+        warn!(
+            "Unable to generate the logging path to pass to set up: {}",
+            e
+        )
     }
 
     match rpc_looper.mainloop(|| stdin.lock(), &mut state) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -194,21 +194,21 @@ fn main() {
     let logfile_config = generate_logfile_config(&flags);
 
     let logging_path_result: Result<PathBuf, io::Error> = generate_logging_path(logfile_config);
-    let logging_path: Option<PathBuf> = match logging_path_result {
-        Ok(val) => Some(val),
-        Err(e) => {
-            eprintln!(
-                "[WARNING] Unable to successfully generate the logging path: {:?}",
-                e
-            );
-            None
-        }
+
+    let mut logging_path: Option<PathBuf> = None;
+    let mut logging_error: Option<io::Error> = None;
+    match logging_path_result {
+        Ok(val) => logging_path = Some(val),
+        Err(e) => logging_error = Some(e),
     };
     if let Err(e) = setup_logging(logging_path) {
         eprintln!(
             "[ERROR] setup_logging returned error, logging disabled: {:?}",
             e
         );
+    }
+    if let Some(e) = logging_error {
+        warn!("Unable to successfully generate the logging path: {:?}", e)
     }
 
     match rpc_looper.mainloop(|| stdin.lock(), &mut state) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -48,15 +48,6 @@ fn get_logging_directory_path<P: AsRef<Path>>(directory: P) -> Result<PathBuf, i
     }
 }
 
-fn path_for_log_file<P: AsRef<Path>>(filename: P) -> Result<PathBuf, io::Error> {
-    let mut logging_directory = get_logging_directory_path(get_logfile_directory_name())?;
-    // Create the logging directory
-    fs::create_dir_all(&logging_directory)?;
-    // Pushing the filename to the end
-    logging_directory.push(filename.as_ref());
-    Ok(logging_directory)
-}
-
 fn setup_logging(logging_path_result: Result<PathBuf, io::Error>) -> Result<(), fern::InitError> {
     let level_filter = match std::env::var("XI_LOG") {
         Ok(level) => match level.to_lowercase().as_ref() {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -150,6 +150,17 @@ fn get_flags() -> HashMap<String, Option<String>> {
     flags
 }
 
+fn generate_logfile_config(flags: HashMap<String, Option<String>>) -> LogfileConfig {
+    // If the key is set, get the Option within
+    let log_dir_flag_option = flags.get("log-dir").cloned().unwrap_or(None);
+    let log_file_flag_option = flags.get("log-file").cloned().unwrap_or(None);
+
+    LogfileConfig {
+        directory: log_dir_flag_option,
+        file: log_file_flag_option,
+    }
+}
+
 fn main() {
     let mut state = XiCore::new();
     let stdin = io::stdin();
@@ -158,14 +169,7 @@ fn main() {
 
     let flags: HashMap<String, Option<String>> = get_flags();
 
-    // If the key is set, get the Option within
-    let log_dir_flag_option = flags.get("log-dir").cloned().unwrap_or(None);
-    let log_file_flag_option = flags.get("log-file").cloned().unwrap_or(None);
-
-    let logfile_config = LogfileConfig {
-        directory: log_dir_flag_option,
-        file: log_file_flag_option,
-    };
+    let logfile_config = generate_logfile_config(flags);
 
     let logging_path: Result<PathBuf, io::Error> = prepare_logging_path(logfile_config);
     if let Err(e) = setup_logging(logging_path) {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -203,7 +203,7 @@ fn main() {
     };
     if let Err(e) = setup_logging(logging_path) {
         eprintln!(
-            "[ERROR] setup_logging returned error, logging disabled: {:?}",
+            "[ERROR] setup_logging returned error, logging not enabled: {:?}",
             e
         );
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -86,7 +86,7 @@ fn create_log_directory(path_with_file: &PathBuf) -> Result<(), io::Error> {
     Ok(())
 }
 
-fn setup_logging(logging_path_result: Option<PathBuf>) -> Result<(), fern::InitError> {
+fn setup_logging(logging_path: Option<PathBuf>) -> Result<(), fern::InitError> {
     let level_filter = match std::env::var("XI_LOG") {
         Ok(level) => match level.to_lowercase().as_ref() {
             "trace" => log::LevelFilter::Trace,
@@ -109,7 +109,7 @@ fn setup_logging(logging_path_result: Option<PathBuf>) -> Result<(), fern::InitE
         }).level(level_filter)
         .chain(io::stderr());
 
-    if let Some(logging_file_path) = &logging_path_result {
+    if let Some(logging_file_path) = &logging_path {
         // Try to create the parent directories for the logging file in the logging file path
         create_log_directory(&logging_file_path)?;
 
@@ -123,11 +123,8 @@ fn setup_logging(logging_path_result: Option<PathBuf>) -> Result<(), fern::InitE
 
     // Log details of the logging_file_path result using fern/log
     // Either logging the path fern is outputting to or the error from obtaining the path
-    match &logging_path_result {
-        Some(logging_file_path) => info!(
-            "Logging to the following file: {}",
-            logging_file_path.display()
-        ),
+    match &logging_path {
+        Some(logging_file_path) => info!("Writing logs to: {}", logging_file_path.display()),
         None => warn!("There was no path supplied for the log file, falling back to stderr."),
     }
     Ok(())

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -108,12 +108,12 @@ fn prepare_logging_path(logfile_config: LogfileConfig) -> Result<PathBuf, io::Er
     // Use the file name set in logfile_config or fallback to the default
     let logfile_file_name = match logfile_config.file {
         Some(file_name) => file_name,
-        None => XI_LOG_FILE.to_string(),
+        None => PathBuf::from(XI_LOG_FILE),
     };
     // Use the directory name set in logfile_config or fallback to the default
     let logfile_directory_name = match logfile_config.directory {
         Some(dir) => dir,
-        None => XI_LOG_DIR.to_string(),
+        None => PathBuf::from(XI_LOG_DIR),
     };
 
     let mut logging_directory_path = get_logging_directory_path(logfile_directory_name)?;
@@ -121,11 +121,6 @@ fn prepare_logging_path(logfile_config: LogfileConfig) -> Result<PathBuf, io::Er
     // Add the file name & return the full path
     logging_directory_path.push(logfile_file_name);
     Ok(logging_directory_path)
-}
-
-struct LogfileConfig {
-    directory: Option<String>,
-    file: Option<String>,
 }
 
 fn get_flags() -> HashMap<String, Option<String>> {
@@ -161,6 +156,11 @@ fn extract_env_or_flag(flags: &HashMap<String, Option<String>>, conf: EnvFlagCon
         .or(flags.get(conf.flag_name).cloned().unwrap_or(None))
 }
 
+struct LogfileConfig {
+    directory: Option<PathBuf>,
+    file: Option<PathBuf>,
+}
+
 fn generate_logfile_config(flags: &HashMap<String, Option<String>>) -> LogfileConfig {
     // If the key is set, get the Option within
     let log_dir_env_flag = EnvFlagConfig {
@@ -171,9 +171,9 @@ fn generate_logfile_config(flags: &HashMap<String, Option<String>>) -> LogfileCo
         env_name: "XI_LOG_FILE",
         flag_name: "log-file",
     };
-    let log_dir_flag_option = extract_env_or_flag(&flags, log_dir_env_flag);
+    let log_dir_flag_option = extract_env_or_flag(&flags, log_dir_env_flag).map(PathBuf::from);
 
-    let log_file_flag_option = extract_env_or_flag(&flags, log_file_env_flag);
+    let log_file_flag_option = extract_env_or_flag(&flags, log_file_env_flag).map(PathBuf::from);
 
     LogfileConfig {
         directory: log_dir_flag_option,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -145,13 +145,17 @@ struct EnvFlagConfig {
     flag_name: &'static str,
 }
 
+/// Extracts a value from the flags and the env.
+///
+/// In this order: `String` from the flags, then `String` from the env, then `None`
 fn extract_env_or_flag(
     flags: &HashMap<String, Option<String>>,
     conf: EnvFlagConfig,
 ) -> Option<String> {
-    std::env::var(conf.env_name)
-        .ok()
-        .or(flags.get(conf.flag_name).cloned().unwrap_or(None))
+    flags
+        .get(conf.flag_name)
+        .cloned()
+        .unwrap_or(std::env::var(conf.env_name).ok())
 }
 
 struct LogfileConfig {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,18 +122,18 @@ fn get_flags() -> HashMap<String, Option<String>> {
     let mut flags: HashMap<String, Option<String>> = HashMap::new();
 
     let flag_prefix = "-";
-    let mut args_itterator = std::env::args().peekable();
-    while let Some(arg) = args_itterator.next() {
+    let mut args_iterator = std::env::args().peekable();
+    while let Some(arg) = args_iterator.next() {
         if arg.starts_with(flag_prefix) {
             let key = arg.trim_left_matches(flag_prefix).to_string();
 
             // Check the next argument doesn't start with the flag prefix
             // map_or accounts for peek returning an Option
-            let next_arg_not_a_flag: bool = args_itterator
+            let next_arg_not_a_flag: bool = args_iterator
                 .peek()
                 .map_or(false, |val| !val.starts_with(flag_prefix));
             if next_arg_not_a_flag {
-                flags.insert(key, args_itterator.next());
+                flags.insert(key, args_iterator.next());
             }
         }
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -125,7 +125,7 @@ fn setup_logging(logging_path: Option<PathBuf>) -> Result<(), fern::InitError> {
     // Either logging the path fern is outputting to or the error from obtaining the path
     match &logging_path {
         Some(logging_file_path) => info!("Writing logs to: {}", logging_file_path.display()),
-        None => warn!("No path was supplied for the log file, not saving logs to disk, falling back to just stderr"),
+        None => warn!("No path was supplied for the log file. Not saving logs to disk, falling back to just stderr"),
     }
     Ok(())
 }


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
Add a way to override the default locations for the log file. This can be useful for frontend's that use the `xi-core` and want all the logs in one place.  
This also allows for users to use multiple frontends that keep their `xi-core` logging separate.  
For example: If I was to use `xi-mac` and `xi-tui` with the `xi-core` (on a Mac) as it is now they would both be logging to the same file (`/Users/MyUserName/Library/Application Support/xi-core/xi-core.log`) which can be a pain when debugging to name just one issue.

This PR deals strictly with adding the ability to change the log file name and/or directory. A future PR will deal with extending this to the `xi-lsp-plugin.log` file which `xi-core` also writes to.



<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues

<!---
GitHub has built-in functionality for closing issues when PR's are merged. TLDR: `closes #1` closes issue number 1 when the PR merges.
See [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) for more info.
--->
Relates to #836

<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->
## Checklist


- [X] Can choose a different **directory name** for the log file
  - Default name: `xi-core`
  - Example:
    - [X] `xi-core --log-dir cool`
    - [X] `XI_LOG_DIR="cool" xi-core`
    - `XI_LOG_DIR="uncool" xi-core --log-dir cool`
  - Resulting location:
    - Linux/Redox: `/home/username123/.local/share/cool/xi-core.log`
    - Mac: `/User/username123/Application Support/cool/xi-core.log`
    - Windows:`C:\Users\username123\AppData\local\cool\xi-core.log`
- [X] Can choose a different **file name** for the log file
  - Default name: `xi-core.log`
  - Example:
    - [X] `xi-core --log-file amazing.log`
    - [X] `XI_LOG_FILE="amazing.log" xi-core`
    - `XI_LOG_FILE="unamazing.log" xi-core --log-file amazing.log`
  - Resulting location:
    - Linux/Redox: `/home/username123/.local/share/xi-core/amazing.log`
    - Mac: `/User/username123/Application Support/xi-core/amazing.log`
    - Windows:`C:\Users\username123\AppData\local\xi-core\amazing.log`
- See comment below.    ~*Optional* - Can completely override the path (maybe with the flag `--log-dir` or a new flag called `--log-path`)~
  - ~Example: `xi-core --log-path /User/username123/some_dir/other_dir`~
  - ~Resulting location: `/User/username123/some_dir/other_dir/xi-core.log`~

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
