### PR TITLE
Use language from core in plugins

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -80,6 +80,7 @@ will receive a `theme_changed` notification.
 `set_language {"view-id":"view-id-1", "language_id":"Rust"}`
 
 Asks core to change the language of the buffer associated with the `view_id`.
+If the change succeeds the client will receive a `language_changed` notification.
 
 ### modify_user_config
 
@@ -326,7 +327,7 @@ This find command supports multiple search queries.
 
 `multi_find [{"id": 1, "chars": "a", "case_sensitive": false, "regex": false, "whole_words": true}]`
 Parameters `regex` and `whole_words` are optional and by default `false`. `id` is an optional parameter
-used to uniquely identify a search query. If left empty, the query is considered as a new query and 
+used to uniquely identify a search query. If left empty, the query is considered as a new query and
 the backend will generate a new ID.
 
 Sets the current search queries and options.
@@ -570,6 +571,12 @@ instance.
 `available_themes {"themes": ["InspiredGitHub"]}`
 
 Notifies the client of the available themes.
+
+#### language_changed
+
+`language_changed {"view_id": "view-id-1", "language_id": "Rust"}`
+
+Notifies the client that the language used for syntax highlighting has been changed.
 
 #### available_languages
 

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -85,6 +85,14 @@ impl Client {
                                      }));
     }
 
+    pub fn language_changed(&self, view_id: ViewId, new_lang: &LanguageId) {
+        self.0.send_rpc_notification("language_changed",
+                                     &json!({
+                                         "view_id": view_id,
+                                         "language_id": new_lang,
+                                     }));
+    }
+
     /// Notify the client that a plugin has started.
     pub fn plugin_started(&self, view_id: ViewId, plugin: &str) {
         self.0.send_rpc_notification("plugin_started",

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -308,12 +308,14 @@ impl ConfigManager {
     /// Sets a specific language for the given buffer. This is used if the
     /// user selects a specific language in the frontend, for instance.
     #[allow(dead_code)]
-    pub(crate) fn override_language(&mut self, id: BufferId, new_lang: LanguageId) {
+    pub(crate) fn override_language(&mut self, id: BufferId, new_lang: LanguageId) -> Option<Table> {
         let has_changed = self.buffer_tags.get_mut(&id)
             .map(|tag| tag.set_user(Some(new_lang)))
             .expect("buffer must exist");
         if has_changed {
-            self.update_buffer_config(id);
+            self.update_buffer_config(id)
+        } else {
+            None
         }
     }
 

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -307,7 +307,6 @@ impl ConfigManager {
 
     /// Sets a specific language for the given buffer. This is used if the
     /// user selects a specific language in the frontend, for instance.
-    #[allow(dead_code)]
     pub(crate) fn override_language(&mut self, id: BufferId, new_lang: LanguageId) -> Option<Table> {
         let has_changed = self.buffer_tags.get_mut(&id)
             .map(|tag| tag.set_user(Some(new_lang)))

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -343,6 +343,10 @@ impl<'a> EventContext<'a> {
         self.render()
     }
 
+    pub(crate) fn language_changed(&mut self, lang_id: &LanguageId) {
+        self.plugins.iter().for_each(|plug| plug.language_changed(self.view_id, lang_id));
+    }
+
     pub(crate) fn reload(&mut self, text: Rope) {
         //TODO: It would be nice if we could preserve the existing selections,
         //but to do that correctly we would need to compute a real delta between
@@ -439,7 +443,7 @@ impl<'a> EventContext<'a> {
             Err(err) => warn!("Hover Response from Client Error {:?}", err)
         }
     }
-     
+
     /// Gives the requested position in UTF-8 offset format to be sent to plugin
     /// If position is `None`, it tries to get the current Caret Position and use
     /// that instead

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -344,9 +344,15 @@ impl<'a> EventContext<'a> {
         self.render()
     }
 
-    pub(crate) fn language_changed(&mut self, lang_id: &LanguageId) {
-        self.client.language_changed(self.view_id, lang_id);
-        self.plugins.iter().for_each(|plug| plug.language_changed(self.view_id, lang_id));
+    pub(crate) fn language_changed(
+        &mut self,
+        old_language_id: &LanguageId,
+        new_language_id: &LanguageId
+    ) {
+        self.language = new_language_id.clone();
+        self.client.language_changed(self.view_id, new_language_id);
+        self.plugins.iter()
+            .for_each(|plug| plug.language_changed(self.view_id, old_language_id, new_language_id));
     }
 
     pub(crate) fn reload(&mut self, text: Rope) {

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -346,13 +346,12 @@ impl<'a> EventContext<'a> {
 
     pub(crate) fn language_changed(
         &mut self,
-        old_language_id: &LanguageId,
         new_language_id: &LanguageId
     ) {
         self.language = new_language_id.clone();
         self.client.language_changed(self.view_id, new_language_id);
         self.plugins.iter()
-            .for_each(|plug| plug.language_changed(self.view_id, old_language_id, new_language_id));
+            .for_each(|plug| plug.language_changed(self.view_id, new_language_id));
     }
 
     pub(crate) fn reload(&mut self, text: Rope) {

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -308,6 +308,7 @@ impl<'a> EventContext<'a> {
                                       &available_plugins);
 
         self.client.config_changed(self.view_id, config);
+        self.client.language_changed(self.view_id, &self.language);
         self.update_wrap_state();
         self.render()
     }
@@ -344,6 +345,7 @@ impl<'a> EventContext<'a> {
     }
 
     pub(crate) fn language_changed(&mut self, lang_id: &LanguageId) {
+        self.client.language_changed(self.view_id, lang_id);
         self.plugins.iter().for_each(|plug| plug.language_changed(self.view_id, lang_id));
     }
 

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -33,6 +33,7 @@ use xi_trace;
 use WeakXiCore;
 use config::Table;
 use tabs::ViewId;
+use syntax::LanguageId;
 
 use self::rpc::{PluginUpdate, PluginBufferInfo};
 
@@ -128,15 +129,21 @@ impl Plugin {
                                                 "changes": changes}))
     }
 
+    pub fn language_changed(&self, view_id: ViewId, new_lang: &LanguageId) {
+        self.peer.send_rpc_notification("language_changed",
+                                        &json!({"view_id": view_id,
+                                                "new_lang": new_lang}))
+    }
+
     pub fn get_hover(&self, view_id: ViewId, request_id: usize, position: usize) {
-        self.peer.send_rpc_notification("get_hover", 
+        self.peer.send_rpc_notification("get_hover",
                                         &json!({"view_id": view_id,
                                                 "request_id": request_id,
                                                 "position": position}))
     }
 
     pub fn dispatch_command(&self, view_id: ViewId, method: &str, params: &Value) {
-        self.peer.send_rpc_notification("custom_command", 
+        self.peer.send_rpc_notification("custom_command",
                                         &json!({"view_id": view_id,
                                                 "method": method,
                                                 "params": params}))

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -129,10 +129,9 @@ impl Plugin {
                                                 "changes": changes}))
     }
 
-    pub fn language_changed(&self, view_id: ViewId, old_lang: &LanguageId, new_lang: &LanguageId) {
+    pub fn language_changed(&self, view_id: ViewId, new_lang: &LanguageId) {
         self.peer.send_rpc_notification("language_changed",
                                         &json!({"view_id": view_id,
-                                                "old_lang": old_lang,
                                                 "new_lang": new_lang}))
     }
 

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -129,9 +129,10 @@ impl Plugin {
                                                 "changes": changes}))
     }
 
-    pub fn language_changed(&self, view_id: ViewId, new_lang: &LanguageId) {
+    pub fn language_changed(&self, view_id: ViewId, old_lang: &LanguageId, new_lang: &LanguageId) {
         self.peer.send_rpc_notification("language_changed",
                                         &json!({"view_id": view_id,
+                                                "old_lang": old_lang,
                                                 "new_lang": new_lang}))
     }
 

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -112,6 +112,7 @@ pub enum HostNotification {
     GetHover { view_id: ViewId, request_id: usize, position: usize },
     Shutdown(EmptyStruct),
     TracingConfig {enabled: bool},
+    LanguageChanged { view_id: ViewId, new_lang: LanguageId },
 }
 
 

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -112,7 +112,7 @@ pub enum HostNotification {
     GetHover { view_id: ViewId, request_id: usize, position: usize },
     Shutdown(EmptyStruct),
     TracingConfig {enabled: bool},
-    LanguageChanged { view_id: ViewId, old_lang: LanguageId, new_lang: LanguageId },
+    LanguageChanged { view_id: ViewId, new_lang: LanguageId },
 }
 
 

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -112,7 +112,7 @@ pub enum HostNotification {
     GetHover { view_id: ViewId, request_id: usize, position: usize },
     Shutdown(EmptyStruct),
     TracingConfig {enabled: bool},
-    LanguageChanged { view_id: ViewId, new_lang: LanguageId },
+    LanguageChanged { view_id: ViewId, old_lang: LanguageId, new_lang: LanguageId },
 }
 
 

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -15,14 +15,14 @@
 //! Very basic syntax detection.
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::path::Path;
 use std::sync::Arc;
 
 use config::Table;
 
 /// The canonical identifier for a particular `LanguageDefinition`.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct LanguageId(Arc<String>);
 
 /// Describes a `LanguageDefinition`. Although these are provided by plugins,
@@ -41,13 +41,13 @@ pub struct LanguageDefinition {
 /// A repository of all loaded `LanguageDefinition`s.
 #[derive(Debug, Default)]
 pub struct Languages {
-    named: HashMap<LanguageId, Arc<LanguageDefinition>>,
+    named: BTreeMap<LanguageId, Arc<LanguageDefinition>>,
     extensions: HashMap<String, Arc<LanguageDefinition>>,
 }
 
 impl Languages {
     pub fn new(language_defs: &[LanguageDefinition]) -> Self {
-        let mut named = HashMap::new();
+        let mut named = BTreeMap::new();
         let mut extensions = HashMap::new();
         for lang in language_defs.iter() {
             let lang_arc = Arc::new(lang.clone());

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -41,6 +41,7 @@ pub struct LanguageDefinition {
 /// A repository of all loaded `LanguageDefinition`s.
 #[derive(Debug, Default)]
 pub struct Languages {
+    // NOTE: BTreeMap is used for sorting the languages by name alphabetically
     named: BTreeMap<LanguageId, Arc<LanguageDefinition>>,
     extensions: HashMap<String, Arc<LanguageDefinition>>,
 }

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -541,10 +541,12 @@ impl CoreState {
     fn do_set_language(&mut self, view_id: ViewId, language_id: LanguageId) {
         if let Some(view) = self.views.get(&view_id) {
             let buffer_id = view.borrow().get_buffer_id();
-            self.make_context(view_id).unwrap().language_changed(&language_id);
-            let changes = self.config_manager.override_language(buffer_id, language_id);
+            let changes = self.config_manager.override_language(buffer_id, language_id.clone());
+
+            let mut context = self.make_context(view_id).unwrap();
+            context.language_changed(&language_id);
             if let Some(changes) = changes {
-                self.make_context(view_id).unwrap().config_changed(&changes);
+                context.config_changed(&changes);
             }
         }
     }

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -504,11 +504,10 @@ impl CoreState {
     fn do_set_language(&mut self, view_id: ViewId, language_id: LanguageId) {
         if let Some(view) = self.views.get(&view_id) {
             let buffer_id = view.borrow().get_buffer_id();
-            let old_language_id = self.config_manager.get_buffer_language(buffer_id);
             let changes = self.config_manager.override_language(buffer_id, language_id.clone());
 
             let mut context = self.make_context(view_id).unwrap();
-            context.language_changed(&old_language_id, &language_id);
+            context.language_changed(&language_id);
             if let Some(changes) = changes {
                 context.config_changed(&changes);
             }

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -43,6 +43,7 @@ fn test_startup() {
     assert_eq!(rx.expect_response(), Ok(json!("view-id-1")));
     rx.expect_rpc("available_plugins");
     rx.expect_rpc("config_changed");
+    rx.expect_rpc("language_changed");
     rx.expect_rpc("update");
     rx.expect_rpc("scroll_to");
     rx.expect_nothing();
@@ -182,6 +183,7 @@ fn test_settings_commands() {
     rx.expect_response().unwrap();
     rx.expect_rpc("available_plugins");
     rx.expect_rpc("config_changed");
+    rx.expect_rpc("language_changed");
     rx.expect_rpc("update");
     rx.expect_rpc("scroll_to");
 

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -97,15 +97,16 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         v.config = conf.unwrap();
     }
 
-    fn do_language_changed(&mut self, view_id: ViewId, old_lang: LanguageId, new_lang: LanguageId) {
+    fn do_language_changed(&mut self, view_id: ViewId, new_lang: LanguageId) {
         let v = bail!(
             self.views.get_mut(&view_id),
             "language_changed",
             self.pid,
             view_id
         );
-        v.set_language(new_lang.clone());
-        self.plugin.language_changed(v, old_lang, new_lang);
+        let old_lang = v.language_id.clone();
+        v.set_language(new_lang);
+        self.plugin.language_changed(v, old_lang);
     }
 
     fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
@@ -203,8 +204,8 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
                 self.do_tracing_config(enabled),
             GetHover {  view_id, request_id, position } =>
                 self.do_get_hover(view_id, request_id, position),
-            LanguageChanged { view_id, old_lang, new_lang } =>
-                self.do_language_changed(view_id, old_lang, new_lang),
+            LanguageChanged { view_id, new_lang } =>
+                self.do_language_changed(view_id, new_lang),
             Ping ( .. ) => (),
         }
     }

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -97,14 +97,15 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         v.config = conf.unwrap();
     }
 
-    fn do_language_changed(&mut self, view_id: ViewId, new_lang: LanguageId) {
+    fn do_language_changed(&mut self, view_id: ViewId, old_lang: LanguageId, new_lang: LanguageId) {
         let v = bail!(
             self.views.get_mut(&view_id),
             "language_changed",
             self.pid,
             view_id
         );
-        self.plugin.language_changed(v, new_lang);
+        v.set_language(new_lang.clone());
+        self.plugin.language_changed(v, old_lang, new_lang);
     }
 
     fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
@@ -202,8 +203,8 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
                 self.do_tracing_config(enabled),
             GetHover {  view_id, request_id, position } =>
                 self.do_get_hover(view_id, request_id, position),
-            LanguageChanged { view_id, new_lang } =>
-                self.do_language_changed(view_id, new_lang),
+            LanguageChanged { view_id, old_lang, new_lang } =>
+                self.do_language_changed(view_id, old_lang, new_lang),
             Ping ( .. ) => (),
         }
     }

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -41,7 +41,7 @@ use std::path::Path;
 
 use xi_rpc::{RpcLoop, ReadError};
 use xi_rope::rope::RopeDelta;
-use xi_core::ConfigTable;
+use xi_core::{ConfigTable, LanguageId};
 use xi_core::plugin_rpc::{GetDataResponse, TextUnit};
 
 use self::dispatch::Dispatcher;
@@ -81,9 +81,9 @@ pub trait Cache {
     /// [`DataSource`]: trait.DataSource.html
     fn get_line<DS: DataSource>(&mut self, source: &DS, line_num: usize)
         -> Result<&str, Error>;
-    
+
     /// Returns the entire contents of the remote document, fetching as needed.
-    fn get_document<DS: DataSource>(&mut self, source: &DS) -> Result<String, Error>; 
+    fn get_document<DS: DataSource>(&mut self, source: &DS) -> Result<String, Error>;
 
     /// Returns the offset of the line at `line_num`, zero-indexed, fetching
     /// data from `source` if needed.
@@ -145,6 +145,9 @@ pub trait Plugin {
                       view: &mut View<Self::Cache>,
                       changes: &ConfigTable);
 
+    #[allow(unused_variables)]
+    fn language_changed(&mut self, view: &mut View<Self::Cache>, new_lang: LanguageId) {}
+
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that
     /// are doing things like full document analysis can use this mechanism
@@ -153,7 +156,7 @@ pub trait Plugin {
     fn idle(&mut self, view: &mut View<Self::Cache>) { }
 
     /// Language Plugins specific methods
-    
+
     #[allow(unused_variables)]
     fn get_hover(&mut self, view: &mut View<Self::Cache>, request_id: usize, position: usize) { }
 }

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -146,7 +146,12 @@ pub trait Plugin {
                       changes: &ConfigTable);
 
     #[allow(unused_variables)]
-    fn language_changed(&mut self, view: &mut View<Self::Cache>, new_lang: LanguageId) {}
+    fn language_changed(
+        &mut self,
+        view: &mut View<Self::Cache>,
+        old_lang: LanguageId,
+        new_lang: LanguageId
+    ) {}
 
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -145,13 +145,10 @@ pub trait Plugin {
                       view: &mut View<Self::Cache>,
                       changes: &ConfigTable);
 
+    /// Called when syntax language has changed for this view.
+    /// New language is available in the `view`, and old language is available in `old_lang`.
     #[allow(unused_variables)]
-    fn language_changed(
-        &mut self,
-        view: &mut View<Self::Cache>,
-        old_lang: LanguageId,
-        new_lang: LanguageId
-    ) {}
+    fn language_changed(&mut self, view: &mut View<Self::Cache>, old_lang: LanguageId) {}
 
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -16,7 +16,7 @@ use std::path::{PathBuf, Path};
 use serde_json::{self, Value};
 use serde::Deserialize;
 
-use xi_core::{ViewId, PluginPid, BufferConfig, ConfigTable};
+use xi_core::{ViewId, PluginPid, BufferConfig, ConfigTable, LanguageId};
 use xi_core::plugin_rpc::{TextUnit, PluginEdit, GetDataResponse, ScopeSpan, PluginBufferInfo};
 use xi_rope::rope::RopeDelta;
 use xi_trace::trace_block;
@@ -41,13 +41,14 @@ pub struct View<C> {
     pub undo_group: Option<usize>,
     buf_size: usize,
     pub (crate) view_id: ViewId,
+    pub (crate) language_id: LanguageId,
 }
 
 impl<C: Cache> View<C> {
     pub (crate) fn new(peer: RpcPeer, plugin_id: PluginPid,
                        info: PluginBufferInfo) -> Self {
         let PluginBufferInfo {
-            views, rev, path, config, buf_size, nb_lines, ..
+            views, rev, path, config, buf_size, nb_lines, syntax, ..
         } = info;
 
         assert_eq!(views.len(), 1, "assuming single view");
@@ -64,6 +65,7 @@ impl<C: Cache> View<C> {
             rev: rev,
             undo_group: None,
             buf_size: buf_size,
+            language_id: syntax,
         }
     }
 
@@ -96,6 +98,10 @@ impl<C: Cache> View<C> {
 
     pub fn get_path(&self) -> Option<&Path> {
         self.path.as_ref().map(PathBuf::as_path)
+    }
+
+    pub fn get_language_id(&self) -> &LanguageId {
+        &self.language_id
     }
 
     pub fn get_config(&self) -> &BufferConfig {

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -77,6 +77,10 @@ impl<C: Cache> View<C> {
         self.buf_size = new_len;
     }
 
+    pub (crate) fn set_language(&mut self, new_language_id: LanguageId) {
+        self.language_id = new_language_id;
+    }
+
     //NOTE: (discuss in review) this feels bad, but because we're mutating cache,
     // which we own, we can't just pass in a reference to something else we own;
     // so we create this on each call. The `clone`is only cloning an `Arc`,

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -193,9 +193,9 @@ impl<'a> Syntect<'a> {
     }
 
     /// Wipes any existing state and starts highlighting with `syntax`.
-    fn do_highlighting(&mut self, view: &mut MyView, lang: Option<&LanguageId>) {
+    fn do_highlighting(&mut self, view: &mut MyView) {
         let initial_state = {
-            let language_id = lang.unwrap_or(view.get_language_id());
+            let language_id = view.get_language_id();
             let syntax = self
                 .syntax_set
                 .find_syntax_by_name(language_id.as_ref())
@@ -297,7 +297,7 @@ impl<'a> Plugin for Syntect<'a> {
         let view_id = view.get_id();
         let state = PluginState::new();
         self.view_state.insert(view_id, state);
-        self.do_highlighting(view, None);
+        self.do_highlighting(view);
     }
 
     fn did_close(&mut self, view: &View<Self::Cache>) {
@@ -306,13 +306,18 @@ impl<'a> Plugin for Syntect<'a> {
 
     fn did_save(&mut self, view: &mut View<Self::Cache>, _old: Option<&Path>) {
         let _t = trace_block("Syntect::did_save", &["syntect"]);
-        self.do_highlighting(view, None);
+        self.do_highlighting(view);
     }
 
     fn config_changed(&mut self, _view: &mut View<Self::Cache>, _changes: &ConfigTable) {}
 
-    fn language_changed(&mut self, view: &mut View<Self::Cache>, new_lang: LanguageId) {
-        self.do_highlighting(view, Some(&new_lang));
+    fn language_changed(
+        &mut self,
+        view: &mut View<Self::Cache>,
+        _old_lang: LanguageId,
+        _new_lang: LanguageId
+    ) {
+        self.do_highlighting(view);
     }
 
     fn update(&mut self, view: &mut View<Self::Cache>, delta: Option<&RopeDelta>,

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -311,12 +311,7 @@ impl<'a> Plugin for Syntect<'a> {
 
     fn config_changed(&mut self, _view: &mut View<Self::Cache>, _changes: &ConfigTable) {}
 
-    fn language_changed(
-        &mut self,
-        view: &mut View<Self::Cache>,
-        _old_lang: LanguageId,
-        _new_lang: LanguageId
-    ) {
+    fn language_changed(&mut self, view: &mut View<Self::Cache>, _old_lang: LanguageId) {
         self.do_highlighting(view);
     }
 


### PR DESCRIPTION
## Summary

Currently, the language for syntax highlighting is determined in two places: in the core and in the syntect plugin. In order for the client to be able to change the language, we need to make the core the single source of truth (for languages, at least).

In this pull request:

- The syntect plugin is no longer guessing the language. Instead, it uses the language from the core.
- The core now notifies plugins and clients about language changes via `language_changed` RPC.

NOTE: I didn't write/run tests or add any docs yet. This is just a first preview.
NOTE 2: The only test I did is I compiled my local version of xi-mac with those changes, and everything worked as expected.
NOTE 3: You can see this working with this [version of xi-mac](https://github.com/xi-editor/xi-mac/pull/294).

## Related Issues

Related to [#282](https://github.com/xi-editor/xi-mac/issues/282)
Closes #891 

## Checklist

- [x] Make syntect use core-identified language on view init (fall back to plain text)
- [x] Send `language_changed` RPC to plugins
- [x] Handle `language_changed` RPC in syntect
- [x] Send `language_changed` RPC to client

## Review Checklist

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.