### PR TITLE
MultiLineSelect doesn't need to move cursor

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -639,6 +639,7 @@ mod tests {
     #[test]
     fn test_gestures() {
         use rpc::GestureType::*;
+        use rpc::MouseAction;
         let initial_text = "\
         this is a string\n\
         that has three\n\
@@ -733,11 +734,11 @@ mod tests {
         that has three\n\
         [lines.|]" );
 
-        ctx.do_edit(EditNotification::Gesture { line: 1, col: 2, ty: MultiLineSelect });
+        ctx.do_edit(EditNotification::Drag(MouseAction { line: 1, column: 2, flags: 0, click_count: Some(1) }));
         assert_eq!(harness.debug_render(),"\
         this is a string|\n\
-        [th|at has three\n\
-        lines.]" );
+        [that has three\n\
+        lines.|]" );
 
         ctx.do_edit(EditNotification::SelectAll);
         assert_eq!(harness.debug_render(),"\

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -733,6 +733,12 @@ mod tests {
         that has three\n\
         [lines.|]" );
 
+        ctx.do_edit(EditNotification::Gesture { line: 1, col: 2, ty: MultiLineSelect });
+        assert_eq!(harness.debug_render(),"\
+        this is a string|\n\
+        [th|at has three\n\
+        lines.]" );
+
         ctx.do_edit(EditNotification::SelectAll);
         assert_eq!(harness.debug_render(),"\
         [this is a string\n\

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -133,6 +133,7 @@ enum WrapWidth {
 }
 
 /// The smallest unit of text that a gesture can select
+#[derive(Copy, Clone)]
 pub enum SelectionGranularity {
     /// Selects any point or character range
     Point,
@@ -504,7 +505,6 @@ impl View {
     /// Does a drag gesture, setting the selection from a combination of the drag
     /// state and new offset.
     fn do_drag(&mut self, text: &Rope, line: u64, col: u64, affinity: Affinity) {
-        let mut is_line = false;
         let offset = self.line_col_to_offset(text, line as usize, col as usize);
         let new_sel = self.drag_state.as_ref().map(|drag_state| {
             let mut sel = drag_state.base_sel.clone();
@@ -531,7 +531,8 @@ impl View {
         });
 
         if let Some(sel) = new_sel {
-            if is_line {
+            let granularity = self.drag_state.as_ref().map(|d| d.granularity);
+            if let Some(SelectionGranularity::Line) = granularity {
                 self.set_selection_raw(text, sel);
             } else {
                 self.set_selection(text, sel);


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
The current Gesture of MultiLineSelect has a bug that the cursor can't go to a position above the starting selection cursor position.  

Also, when you do a line selection, the cursor doesn't need to move to the end of the selection. 


<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues


<!---
GitHub has built-in functionality for closing issues when PR's are merged. TLDR: `closes #1` closes issue number 1 when the PR merges.
See [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) for more info.
--->


<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
