### PR TITLE
Improve sse4.2 string compare performance

### DIFF
--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -36,86 +36,75 @@ static TARG_STR: &str = "This adds some function, I guess?, that has a size set 
 
 Currently my sense of smell (and the pain of implementing Write) might be too much, since bytes will probably always be fed one by one anyway. Otherwise crying might be needed (one by one is inefficient).";
 
+fn make_test_data() -> (Vec<u8>, Vec<u8>) {
+    let one = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat().into_bytes();
+    let mut two = one.clone();
+    let idx = one.len() / 2;
+    two[idx] = 0x02;
+    (one, two)
+}
+
 #[bench]
 fn ne_idx_sw(b: &mut Bencher) {
-    let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    let mut two = one.clone();
-    unsafe {
-        let b = two.as_bytes_mut();
-        let idx = b.len() - 200;
-        b[idx] = 0x02;
-    }
+    let (one, two) = make_test_data();
 
     b.iter(|| {
-        compare::ne_idx_fallback(one.as_bytes(), one.as_bytes());
-        compare::ne_idx_fallback(one.as_bytes(), two.as_bytes());
+        compare::ne_idx_fallback(&one, &one);
+        compare::ne_idx_fallback(&one, &two);
     })
 }
 
 #[bench]
 fn ne_idx_sse(b: &mut Bencher) {
-    let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    let mut two = one.clone();
-    unsafe {
-        let b = two.as_bytes_mut();
-        let idx = b.len() - 200;
-        b[idx] = 0x02;
-    }
+    let (one, two) = make_test_data();
 
     let mut x = 0;
     b.iter(|| {
-        x += compare::ne_idx_sse(one.as_bytes(), one.as_bytes()).unwrap_or_default();
-        x += compare::ne_idx_sse(one.as_bytes(), two.as_bytes()).unwrap_or_default();
+        x += unsafe { compare::ne_idx_sse(&one, &one).unwrap_or_default() };
+        x += unsafe { compare::ne_idx_sse(&one, &two).unwrap_or_default() };
     })
 }
 
 #[bench]
 fn ne_idx_avx(b: &mut Bencher) {
-    let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    let mut two = one.clone();
-    unsafe {
-        let b = two.as_bytes_mut();
-        let idx = b.len() - 200;
-        b[idx] = 0x02;
-    }
+    let (one, two) = make_test_data();
 
     let mut dont_opt_me = 0;
     b.iter(|| {
-        dont_opt_me += compare::ne_idx_avx(one.as_bytes(), two.as_bytes()).unwrap_or_default();
-        dont_opt_me += compare::ne_idx_avx(one.as_bytes(), one.as_bytes()).unwrap_or_default();
+        dont_opt_me += unsafe { compare::ne_idx_avx(&one, &two).unwrap_or_default() };
+        dont_opt_me += unsafe { compare::ne_idx_avx(&one, &one).unwrap_or_default() };
+    })
+}
+
+#[bench]
+fn ne_idx_detect(b: &mut Bencher) {
+    let (one, two) = make_test_data();
+
+    let mut dont_opt_me = 0;
+    b.iter(|| {
+        dont_opt_me += compare::ne_idx(&one, &two).unwrap_or_default();
+        dont_opt_me += compare::ne_idx(&one, &one).unwrap_or_default();
     })
 }
 
 #[bench]
 fn ne_idx_rev_sw(b: &mut Bencher) {
-    let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    let mut two = one.clone();
-    unsafe {
-        let b = two.as_bytes_mut();
-        let idx = 200;
-        b[idx] = 0x02;
-    }
+    let (one, two) = make_test_data();
 
     let mut x = 0;
     b.iter(|| {
-        x += compare::ne_idx_rev_fallback(one.as_bytes(), one.as_bytes()).unwrap_or_default();
-        x += compare::ne_idx_rev_fallback(one.as_bytes(), two.as_bytes()).unwrap_or_default();
+        x += compare::ne_idx_rev_fallback(&one, &one).unwrap_or_default();
+        x += compare::ne_idx_rev_fallback(&one, &two).unwrap_or_default();
     })
 }
 
 #[bench]
 fn ne_idx_rev_sse(b: &mut Bencher) {
-    let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    let mut two = one.clone();
-    unsafe {
-        let b = two.as_bytes_mut();
-        let idx = 200;
-        b[idx] = 0x02;
-    }
+    let (one, two) = make_test_data();
 
     b.iter(|| {
-        compare::ne_idx_rev_sse(one.as_bytes(), one.as_bytes());
-        compare::ne_idx_rev_sse(one.as_bytes(), two.as_bytes());
+        compare::ne_idx_rev_sse(&one, &one);
+        compare::ne_idx_rev_sse(&one, &two);
     })
 }
 

--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -53,7 +53,7 @@ fn ne_idx_sw(b: &mut Bencher) {
 }
 
 #[bench]
-fn ne_idx_hw(b: &mut Bencher) {
+fn ne_idx_sse(b: &mut Bencher) {
     let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
     let mut two = one.clone();
     unsafe {
@@ -62,17 +62,16 @@ fn ne_idx_hw(b: &mut Bencher) {
         b[idx] = 0x02;
     }
 
+    let mut x = 0;
     b.iter(|| {
-        compare::ne_idx_sse42(one.as_bytes(), one.as_bytes());
-        compare::ne_idx_sse42(one.as_bytes(), two.as_bytes());
+        x += compare::ne_idx_sse(one.as_bytes(), one.as_bytes()).unwrap_or_default();
+        x += compare::ne_idx_sse(one.as_bytes(), two.as_bytes()).unwrap_or_default();
     })
 }
 
 #[bench]
 fn ne_idx_avx(b: &mut Bencher) {
     let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
-    assert_eq!(compare::ne_idx_fallback(one.as_bytes(), one.as_bytes()), None);
-    assert_eq!(compare::ne_idx_avx(one.as_bytes(), one.as_bytes()), None);
     let mut two = one.clone();
     unsafe {
         let b = two.as_bytes_mut();
@@ -91,7 +90,6 @@ fn ne_idx_avx(b: &mut Bencher) {
 fn ne_idx_rev_sw(b: &mut Bencher) {
     let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
     let mut two = one.clone();
-    assert_eq!(compare::ne_idx_fallback(one.as_bytes(), one.as_bytes()), None);
     unsafe {
         let b = two.as_bytes_mut();
         let idx = 200;
@@ -106,7 +104,7 @@ fn ne_idx_rev_sw(b: &mut Bencher) {
 }
 
 #[bench]
-fn ne_idx_rev_hw(b: &mut Bencher) {
+fn ne_idx_rev_sse(b: &mut Bencher) {
     let one: String = [EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR].concat();
     let mut two = one.clone();
     unsafe {
@@ -116,8 +114,8 @@ fn ne_idx_rev_hw(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        compare::ne_idx_rev_simd(one.as_bytes(), one.as_bytes());
-        compare::ne_idx_rev_simd(one.as_bytes(), two.as_bytes());
+        compare::ne_idx_rev_sse(one.as_bytes(), one.as_bytes());
+        compare::ne_idx_rev_sse(one.as_bytes(), two.as_bytes());
     })
 }
 

--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -55,7 +55,11 @@ fn ne_idx_sw(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(target_arch = "x86_64")]
 fn ne_idx_sse(b: &mut Bencher) {
+    if !is_x86_feature_detected!("sse4.2") {
+        return;
+    }
     let (one, two) = make_test_data();
 
     let mut x = 0;
@@ -66,7 +70,11 @@ fn ne_idx_sse(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(target_arch = "x86_64")]
 fn ne_idx_avx(b: &mut Bencher) {
+    if !is_x86_feature_detected!("avx2") {
+        return;
+    }
     let (one, two) = make_test_data();
 
     let mut dont_opt_me = 0;
@@ -99,10 +107,14 @@ fn ne_idx_rev_sw(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(target_arch = "x86_64")]
 fn ne_idx_rev_sse(b: &mut Bencher) {
+    if !is_x86_feature_detected!("sse4.2") {
+        return;
+    }
     let (one, two) = make_test_data();
 
-    b.iter(|| {
+    b.iter(|| unsafe {
         compare::ne_idx_rev_sse(&one, &one);
         compare::ne_idx_rev_sse(&one, &two);
     })
@@ -116,8 +128,8 @@ fn scanner(b: &mut Bencher) {
 
     let mut scanner = compare::RopeScanner::new(&one, &two);
     b.iter(|| {
-        scanner.find_ne_char_right(0, 0, None);
-        scanner.find_ne_char_left(one.len(), two.len(), None);
+        scanner.find_ne_char(0, 0, None);
+        scanner.find_ne_char_back(one.len(), two.len(), None);
     })
 }
 

--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -20,7 +20,7 @@ extern crate xi_rope;
 use test::Bencher;
 use xi_rope::compare;
 use xi_rope::diff::{Diff, LineHashDiff};
-use xi_rope::rope::RopeDelta;
+use xi_rope::rope::{Rope, RopeDelta};
 
 static EDITOR_STR: &str = include_str!("../../core-lib/src/editor.rs");
 static VIEW_STR: &str = include_str!("../../core-lib/src/view.rs");
@@ -105,6 +105,19 @@ fn ne_idx_rev_sse(b: &mut Bencher) {
     b.iter(|| {
         compare::ne_idx_rev_sse(&one, &one);
         compare::ne_idx_rev_sse(&one, &two);
+    })
+}
+
+#[bench]
+fn scanner(b: &mut Bencher) {
+    let (one, two) = make_test_data();
+    let one = Rope::from(String::from_utf8(one).unwrap());
+    let two = Rope::from(String::from_utf8(two).unwrap());
+
+    let mut scanner = compare::RopeScanner::new(&one, &two);
+    b.iter(|| {
+        scanner.find_ne_char_right(0, 0, None);
+        scanner.find_ne_char_left(one.len(), two.len(), None);
     })
 }
 

--- a/rust/rope/src/diff.rs
+++ b/rust/rope/src/diff.rs
@@ -149,9 +149,9 @@ fn expand_match(
 ) -> (usize, usize) {
     let mut scanner = RopeScanner::new(base, target);
     let max_left = targ_off - prev_match_targ_end;
-    let start = scanner.find_ne_char_left(base_off, targ_off, max_left);
+    let start = scanner.find_ne_char_back(base_off, targ_off, max_left);
     debug_assert!(start <= max_left, "{} <= {}", start, max_left);
-    let end = scanner.find_ne_char_right(base_off, targ_off, None);
+    let end = scanner.find_ne_char(base_off, targ_off, None);
     (start.min(max_left), end)
 }
 


### PR DESCRIPTION
This version just uses bytewise compare, instead of the fancier (and
slower) string-specific operations. This shows a marked improvement, and
the new sse version is actually faster than the avx version, which is
slightly surprising; it may be that the avx loads are higher latency and
that's dominating? I've also only tested on one machine, a laptop with
turbo-boost disabled.

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
