### PR TITLE
Fix accidental use of open_closed intervals

### DIFF
--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(c.cached_offset_of_line(5), None);
 
         // delete a newline, and see that line_offsets is correctly updated
-        let delta = Delta::simple_edit(Interval::new_open_closed(3, 4), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new_closed_open(3, 4), "".into(), c.buf_size);
         assert!(delta.is_simple_delete());
         c.update(Some(&delta), delta.new_document_len(), 3, 1);
         assert_eq!(&c.contents, "zerone\ntwo\ntri");
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(&c.contents, "zer\none\ntwo\ntri");
         assert_eq!(&c.line_offsets, &[4, 8, 12]);
 
-        let delta = Delta::simple_edit(Interval::new_open_closed(3, 4), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new_closed_open(3, 4), "".into(), c.buf_size);
         assert!(delta.is_simple_delete());
         let (iv, _) = delta.summary();
         let start = iv.start();
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(c.get_line(&source, 2).unwrap(), "    let two = \"two\";\n");
         assert_eq!(c.get_line(&source, 3).unwrap(), "}");
 
-        let delta = Delta::simple_edit(Interval::new_open_closed(53, 54), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new_closed_open(53, 54), "".into(), c.buf_size);
         c.update(Some(&delta), base_document.len() - 1, 3, 1);
         source.0 = edited_document.into();
         assert_eq!(c.get_line(&source, 0).unwrap(), "fn main() {\n");

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -350,40 +350,40 @@ mod tests {
         // with    2 2 4 4     8 8
         // ==      3 3 5 5 1 1 9 9 1 16
         let mut sb = SpansBuilder::new(10);
-        sb.add_span(Interval::new_open_closed(0, 9), 1u32);
-        sb.add_span(Interval::new_open_closed(9, 10), 16);
+        sb.add_span(Interval::new_closed_open(0, 9), 1u32);
+        sb.add_span(Interval::new_closed_open(9, 10), 16);
         let red = sb.build();
 
         let mut sb = SpansBuilder::new(10);
-        sb.add_span(Interval::new_open_closed(0, 2), 2);
-        sb.add_span(Interval::new_open_closed(2, 4), 4);
-        sb.add_span(Interval::new_open_closed(6, 8), 8);
+        sb.add_span(Interval::new_closed_open(0, 2), 2);
+        sb.add_span(Interval::new_closed_open(2, 4), 4);
+        sb.add_span(Interval::new_closed_open(6, 8), 8);
         let blue = sb.build();
         let merged = red.merge(&blue, |r, b| b.map(|b| b + r).unwrap_or(*r));
 
         let mut merged_iter = merged.iter();
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(0, 2));
+        assert_eq!(iv, Interval::new_closed_open(0, 2));
         assert_eq!(*val, 3);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(2, 4));
+        assert_eq!(iv, Interval::new_closed_open(2, 4));
         assert_eq!(*val, 5);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(4, 6));
+        assert_eq!(iv, Interval::new_closed_open(4, 6));
         assert_eq!(*val, 1);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(6, 8));
+        assert_eq!(iv, Interval::new_closed_open(6, 8));
         assert_eq!(*val, 9);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(8, 9));
+        assert_eq!(iv, Interval::new_closed_open(8, 9));
         assert_eq!(*val, 1);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(9, 10));
+        assert_eq!(iv, Interval::new_closed_open(9, 10));
         assert_eq!(*val, 16);
 
         assert!(merged_iter.next().is_none());
@@ -394,45 +394,45 @@ mod tests {
         // 1 1 1   4 4
         //   2 2 2 2     8 9
         let mut sb = SpansBuilder::new(9);
-        sb.add_span(Interval::new_open_closed(0, 3), 1);
-        sb.add_span(Interval::new_open_closed(4, 6), 4);
+        sb.add_span(Interval::new_closed_open(0, 3), 1);
+        sb.add_span(Interval::new_closed_open(4, 6), 4);
         let blue = sb.build();
 
         let mut sb = SpansBuilder::new(9);
-        sb.add_span(Interval::new_open_closed(1, 5), 2);
-        sb.add_span(Interval::new_open_closed(7, 8), 8);
-        sb.add_span(Interval::new_open_closed(8, 9), 9);
+        sb.add_span(Interval::new_closed_open(1, 5), 2);
+        sb.add_span(Interval::new_closed_open(7, 8), 8);
+        sb.add_span(Interval::new_closed_open(8, 9), 9);
         let red = sb.build();
 
         let merged = red.merge(&blue, |r, b| b.map(|b| b + r).unwrap_or(*r));
 
         let mut merged_iter = merged.iter();
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(0, 1));
+        assert_eq!(iv, Interval::new_closed_open(0, 1));
         assert_eq!(*val, 1);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(1, 3));
+        assert_eq!(iv, Interval::new_closed_open(1, 3));
         assert_eq!(*val, 3);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(3, 4));
+        assert_eq!(iv, Interval::new_closed_open(3, 4));
         assert_eq!(*val, 2);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(4, 5));
+        assert_eq!(iv, Interval::new_closed_open(4, 5));
         assert_eq!(*val, 6);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(5, 6));
+        assert_eq!(iv, Interval::new_closed_open(5, 6));
         assert_eq!(*val, 4);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(7, 8));
+        assert_eq!(iv, Interval::new_closed_open(7, 8));
         assert_eq!(*val, 8);
 
         let (iv, val) = merged_iter.next().unwrap();
-        assert_eq!(iv, Interval::new_open_closed(8, 9));
+        assert_eq!(iv, Interval::new_closed_open(8, 9));
         assert_eq!(*val, 9);
 
         assert!(merged_iter.next().is_none());

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -234,7 +234,7 @@ impl<'a> Syntect<'a> {
 
                 let indent = self.indent_for_next_line(line, use_spaces, tab_size);
                 let ix = start + text.len();
-                let interval = Interval::new_open_closed(ix, ix);
+                let interval = Interval::new_closed_open(ix, ix);
                 //TODO: view should have a `get_edit_builder` fn?
                 let mut builder = EditBuilder::new(buf_size);
                 builder.replace(interval, indent.into());


### PR DESCRIPTION
There are numerous places where I used open_closed without any
particular rationale; this replaces those with closed_open.

Progress towards #914

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
