### PR TITLE
Positions of matches in find_status

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -695,9 +695,9 @@ Removes a status item from the front end.
 
 Find supports multiple search queries.
 
-`find_status {"view_id": "view-id-1", "queries": [{"id": 1, "chars": "a", "case_sensitive": false, "is_regex": false, "whole_words": true, "matches": 6}]}`
+`find_status {"view_id": "view-id-1", "queries": [{"id": 1, "chars": "a", "case_sensitive": false, "is_regex": false, "whole_words": true, "matches": 6, "lines": [1, 3, 3, 6]}]}`
 
-Notifies the client about the current search queries and search options.
+Notifies the client about the current search queries and search options. `lines` indicates for each match its line number.
 
 #### replace_status
 

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -112,7 +112,7 @@ impl Find {
                 is_regex: None,
                 whole_words: None,
                 matches: self.occurrences.len(),
-                lines: self.occurrences.iter().map(|o| view.offset_to_line_col(text, o.min()).0).collect(),
+                lines: self.occurrences.iter().map(|o| view.offset_to_line_col(text, o.min()).0 + 1).collect(),
             }
         } else {
             FindStatus {
@@ -122,7 +122,7 @@ impl Find {
                 is_regex: Some(self.regex.is_some()),
                 whole_words: Some(self.whole_words),
                 matches: self.occurrences.len(),
-                lines: self.occurrences.iter().map(|o| view.offset_to_line_col(text, o.min()).0).collect(),
+                lines: self.occurrences.iter().map(|o| view.offset_to_line_col(text, o.min()).0 + 1).collect(),
             }
         }
     }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -709,7 +709,7 @@ impl View {
         // send updated find status only if there have been changes
         if self.find_changed != FindStatusChange::None {
             let matches_only = self.find_changed == FindStatusChange::Matches;
-            client.find_status(self.view_id, &json!(self.find_status(matches_only)));
+            client.find_status(self.view_id, &json!(self.find_status(text, matches_only)));
         }
 
         // send updated replace status if changed
@@ -791,11 +791,11 @@ impl View {
 
     /// Determines the current number of find results and search parameters to send them to
     /// the frontend.
-    pub fn find_status(&mut self, matches_only: bool) -> Vec<FindStatus> {
+    pub fn find_status(&mut self, text: &Rope, matches_only: bool) -> Vec<FindStatus> {
         self.find_changed = FindStatusChange::None;
 
         self.find.iter().map(|find| {
-            find.find_status(matches_only)
+            find.find_status(&self, text, matches_only)
         }).collect::<Vec<FindStatus>>()
     }
 


### PR DESCRIPTION
This is currently a WIP and requires some discussion about the protocol changes.

## Summary

I started looking into https://github.com/xi-editor/xi-editor/issues/834 to add the positions of the find matches to `find_status`. For now I added the line numbers of each match to `find_status`, but I was wondering if it makes sense to provide the exact position (start and end since regex could go over multiple lines) or would that be too much information getting sent which might negatively affect performance?

I was thinking to change `find_status` to something like the following: 

```
find_status {
    "view_id": "view-id-1", 
    "queries": [{
        "id": 1, 
        "chars": "a", 
        "case_sensitive": false, 
        "is_regex": false, 
        "whole_words": true, 
        "matches": 6,
        "positions": [{          // This part starting here would be new
            "start_line": 1,
            "start_col": 12,
            "end_line": 1,
            "end_col": 13
        },
        {
            "start_line": 2,
            "start_col": 2,
            "end_line": 2,
            "end_col": 3
        }]
    }]
}
```

Technically, if we send all the positions then `matches` would be redundant. Though, it might still be useful to have as a quick way to get the number of matches?

## Related Issues
https://github.com/xi-editor/xi-editor/issues/834
