### PR TITLE
Make all intervals closed_open

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-rope 0.2.0",
+ "xi-rope 0.3.0",
  "xi-rpc 0.2.0",
  "xi-trace 0.1.0",
  "xi-trace-dump 0.1.0",
@@ -1186,7 +1186,7 @@ dependencies = [
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
- "xi-rope 0.2.0",
+ "xi-rope 0.3.0",
  "xi-rpc 0.2.0",
  "xi-trace 0.1.0",
 ]
@@ -1204,7 +1204,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
- "xi-rope 0.2.0",
+ "xi-rope 0.3.0",
  "xi-rpc 0.2.0",
  "xi-trace 0.1.0",
  "xi-trace-dump 0.1.0",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "xi-rope"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1244,7 +1244,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
- "xi-rope 0.2.0",
+ "xi-rope 0.3.0",
  "xi-trace 0.1.0",
 ]
 
@@ -1258,7 +1258,7 @@ dependencies = [
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
- "xi-rope 0.2.0",
+ "xi-rope 0.3.0",
  "xi-trace 0.1.0",
 ]
 

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -19,7 +19,7 @@ memchr = "2.0.1"
 
 xi-trace = { path = "../trace", version = "0.1.0" }
 xi-trace-dump = { path = "../trace-dump", version = "0.1.0" }
-xi-rope = { path = "../rope", version = "0.2" }
+xi-rope = { path = "../rope", version = "0.3" }
 xi-unicode = { path = "../unicode", version = "0.1.0" }
 xi-rpc = { path = "../rpc", version = "0.2.0" }
 

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -180,7 +180,7 @@ impl Editor {
     /// position when possible.
     pub fn reload(&mut self, text: Rope) {
         let mut builder = delta::Builder::new(self.text.len());
-        let all_iv = Interval::new_closed_open(0, self.text.len());
+        let all_iv = Interval::new(0, self.text.len());
         builder.replace(all_iv, text);
         self.add_delta(builder.build());
         self.set_pristine();
@@ -204,7 +204,7 @@ impl Editor {
         let rope = text.into();
         let mut builder = delta::Builder::new(self.text.len());
         for region in view.sel_regions() {
-            let iv = Interval::new_closed_open(region.min(), region.max());
+            let iv = Interval::new(region.min(), region.max());
             builder.replace(iv, rope.clone());
         }
         self.add_delta(builder.build());
@@ -364,7 +364,7 @@ impl Editor {
         let mut builder = delta::Builder::new(self.text.len());
         for region in view.sel_regions() {
             let start = offset_for_delete_backwards(&view, &region, &self.text, &config);
-            let iv = Interval::new_closed_open(start, region.max());
+            let iv = Interval::new(start, region.max());
             if !iv.is_empty() {
                 builder.delete(iv);
             }
@@ -409,7 +409,7 @@ impl Editor {
     fn delete_sel_regions(&mut self, sel_regions: &[SelRegion]) {
         let mut builder = delta::Builder::new(self.text.len());
         for region in sel_regions {
-            let iv = Interval::new_closed_open(region.min(), region.max());
+            let iv = Interval::new(region.min(), region.max());
             if !iv.is_empty() {
                 builder.delete(iv);
             }
@@ -463,7 +463,7 @@ impl Editor {
                 self.this_edit_type = EditType::Indent;
                 for line in line_range {
                     let offset = view.line_col_to_offset(&self.text, line, 0);
-                    let iv = Interval::new_closed_open(offset, offset);
+                    let iv = Interval::new(offset, offset);
                     builder.replace(iv, Rope::from(const_tab_text));
                 }
             } else {
@@ -472,7 +472,7 @@ impl Editor {
                 tab_size = tab_size - (col % tab_size);
                 let tab_text = self.get_tab_text(config, Some(tab_size));
 
-                let iv = Interval::new_closed_open(region.min(), region.max());
+                let iv = Interval::new(region.min(), region.max());
                 builder.replace(iv, Rope::from(tab_text));
             }
         }
@@ -506,7 +506,7 @@ impl Editor {
         let mut builder = delta::Builder::new(self.text.len());
         for line in lines {
             let offset = view.line_col_to_offset(&self.text, line, 0);
-            let interval = Interval::new_closed_open(offset, offset);
+            let interval = Interval::new(offset, offset);
             builder.replace(interval, Rope::from(tab_text));
 
         }
@@ -520,13 +520,13 @@ impl Editor {
             let offset = view.line_col_to_offset(&self.text, line, 0);
             let tab_offset = view.line_col_to_offset(&self.text, line,
                                                      tab_text.len());
-            let interval = Interval::new_closed_open(offset, tab_offset);
+            let interval = Interval::new(offset, tab_offset);
             let leading_slice = self.text.slice_to_cow(interval.start()..interval.end());
             if leading_slice == tab_text {
                 builder.delete(interval);
             } else if let Some(first_char_col) = leading_slice.find(|c: char| !c.is_whitespace()) {
                 let first_char_offset = view.line_col_to_offset(&self.text, line, first_char_col);
-                let interval = Interval::new_closed_open(offset, first_char_offset);
+                let interval = Interval::new(offset, first_char_offset);
                 builder.delete(interval);
             }
         }
@@ -558,7 +558,7 @@ impl Editor {
         } else {
             let mut builder = delta::Builder::new(self.text.len());
             for (sel, line) in view.sel_regions().iter().zip(chars.lines()) {
-                let iv = Interval::new_closed_open(sel.min(), sel.max());
+                let iv = Interval::new(sel.min(), sel.max());
                 builder.replace(iv, line.into());
             }
             self.add_delta(builder.build());
@@ -603,7 +603,7 @@ impl Editor {
     }
 
     fn sel_region_to_interval_and_rope(&self, region: SelRegion) -> (Interval, Rope) {
-        let as_interval = Interval::new_closed_open(region.min(), region.max());
+        let as_interval = Interval::new(region.min(), region.max());
         let interval_rope = self.text.subseq(as_interval);
         (as_interval, interval_rope)
     }
@@ -631,7 +631,7 @@ impl Editor {
                         end = middle.wrapping_add(1);
                     }
 
-                    let interval = Interval::new_closed_open(start, end);
+                    let interval = Interval::new(start, end);
                     let before =  self.text.slice_to_cow(start..middle);
                     let after = self.text.slice_to_cow(middle..end);
                     let swapped: String = [after, before].concat();
@@ -686,7 +686,7 @@ impl Editor {
 
         for region in view.sel_regions() {
             let selected_text = self.text.slice_to_cow(region);
-            let interval = Interval::new_closed_open(region.min(), region.max());
+            let interval = Interval::new(region.min(), region.max());
             builder.replace(interval, Rope::from(transform_function(&selected_text)));
         }
         if !builder.is_empty() {
@@ -722,7 +722,7 @@ impl Editor {
 
             let word = self.text.slice_to_cow(start..end);
             if let Some(number) = word.parse::<i128>().ok().and_then(&transform_function) {
-                let interval = Interval::new_closed_open(start, end);
+                let interval = Interval::new(start, end);
                 builder.replace(interval, Rope::from(number.to_string()));
             }
         }
@@ -747,7 +747,7 @@ impl Editor {
                 let (start, end) = word_cursor.select_word();
 
                 if start < end {
-                    let interval = Interval::new_closed_open(start, end);
+                    let interval = Interval::new(start, end);
                     let word = self.text.slice_to_cow(start..end);
 
                     // first letter is uppercase, remaining letters are lowercase
@@ -798,7 +798,7 @@ impl Editor {
 
         for (start, end) in to_duplicate {
             // insert duplicates
-            let iv = Interval::new_closed_open(start, start);
+            let iv = Interval::new(start, start);
             builder.replace(iv, self.text.slice(start..end));
 
             // last line does not have new line character so it needs to be manually added
@@ -856,7 +856,7 @@ impl Editor {
         let mut end_offset = start + len;
         let mut sb = SpansBuilder::new(len);
         for span in spans {
-            sb.add_span(Interval::new_open_open(span.start, span.end),
+            sb.add_span(Interval::new(span.start, span.end),
                         span.scope_id);
         }
         let mut spans = sb.build();
@@ -865,13 +865,13 @@ impl Editor {
             let mut transformer = Transformer::new(&delta);
             let new_start = transformer.transform(start, false);
             if !transformer.interval_untouched(
-                Interval::new_closed_closed(start, end_offset)) {
+                Interval::new(start, end_offset)) {
                 spans = spans.transform(start, end_offset, &mut transformer);
             }
             start = new_start;
             end_offset = transformer.transform(end_offset, true);
         }
-        let iv = Interval::new_closed_closed(start, end_offset);
+        let iv = Interval::new(start, end_offset);
         self.layers.update_layer(plugin, iv, spans);
         view.invalidate_styles(&self.text, start, end_offset);
     }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -156,7 +156,7 @@ impl<'a> EventContext<'a> {
             SpecialEvent::DebugPrintSpans => self.with_editor(
                 |ed, view, _, _| {
                     let sel = view.sel_regions().last().unwrap();
-                    let iv = Interval::new_closed_open(sel.min(), sel.max());
+                    let iv = Interval::new(sel.min(), sel.max());
                     ed.get_layers().debug_print_spans(iv);
                 }),
             SpecialEvent::RequestLines(LineRange { first, last }) =>

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -253,7 +253,7 @@ impl Find {
 
         // TODO: this interval might cut a unicode codepoint, make sure it is
         // aligned to codepoint boundaries.
-        let sub_text = text.subseq(Interval::new_closed_open(0, to));
+        let sub_text = text.subseq(Interval::new(0, to));
         let mut find_cursor = Cursor::new(&sub_text, from);
         let mut raw_lines = text.lines_raw(from..to);
 

--- a/rust/core-lib/src/index_set.rs
+++ b/rust/core-lib/src/index_set.rs
@@ -332,15 +332,15 @@ mod tests {
         e.union_one_range(1, 3);
         e.union_one_range(5, 9);
 
-        let d = Delta::simple_edit(Interval::new_closed_open(2, 2), Rope::from("..."), 10);
+        let d = Delta::simple_edit(Interval::new(2, 2), Rope::from("..."), 10);
         let s = e.apply_delta(&d);
         assert_eq!(s.get_ranges(), &[(1, 6), (8, 12)]);
 
-        let d = Delta::simple_edit(Interval::new_closed_open(0, 3), Rope::from(""), 10);
+        let d = Delta::simple_edit(Interval::new(0, 3), Rope::from(""), 10);
         let s = e.apply_delta(&d);
         assert_eq!(s.get_ranges(), &[(2, 6)]);
 
-        let d = Delta::simple_edit(Interval::new_closed_open(2, 6), Rope::from(""), 10);
+        let d = Delta::simple_edit(Interval::new(2, 6), Rope::from(""), 10);
         let s = e.apply_delta(&d);
         assert_eq!(s.get_ranges(), &[(1, 5)]);
     }

--- a/rust/core-lib/src/layers.rs
+++ b/rust/core-lib/src/layers.rs
@@ -95,7 +95,7 @@ impl Layers {
         self.deleted.insert(layer);
         let layer = self.layers.remove(&layer);
         if layer.is_some() {
-            let iv_all = Interval::new_closed_closed(0, self.merged.len());
+            let iv_all = Interval::new(0, self.merged.len());
             //TODO: should Spans<T> have a clear() method?
             self.merged = SpansBuilder::new(self.merged.len()).build();
             self.resolve_styles(iv_all);
@@ -108,7 +108,7 @@ impl Layers {
             layer.theme_changed(style_map);
         }
         self.merged = SpansBuilder::new(self.merged.len()).build();
-        let iv_all = Interval::new_closed_closed(0, self.merged.len());
+        let iv_all = Interval::new(0, self.merged.len());
         self.resolve_styles(iv_all);
     }
 
@@ -191,7 +191,7 @@ impl ScopeLayer {
         // recompute styles with the new theme
         let cur_stacks = self.stack_lookup.clone();
         self.style_lookup = self.styles_for_stacks(&cur_stacks, style_map);
-        let iv_all = Interval::new_closed_closed(0, self.style_spans.len());
+        let iv_all = Interval::new(0, self.style_spans.len());
         self.style_spans = SpansBuilder::new(self.style_spans.len()).build();
         // this feels unnecessary but we can't pass in a reference to self
         // and I don't want to get fancy unless there's an actual perf problem

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -162,7 +162,7 @@ pub fn rewrap(breaks: &mut Breaks, text: &Rope, iv: Interval, newsize: usize, co
         let time_ms = (time::now() - start_time).num_nanoseconds().unwrap() as f64 * 1e-6;
         debug!("time to wrap {} bytes: {:.2}ms (not counting build+edit)",
             inval_end - inval_start, time_ms);
-        (Interval::new_open_closed(inval_start, inval_end + (end - start) - newsize), builder.build())
+        (Interval::new(inval_start, inval_end + (end - start) - newsize), builder.build())
     };
     breaks.edit(edit_iv, new_breaks);
 }
@@ -337,7 +337,7 @@ pub fn rewrap_width(breaks: &mut Breaks, text: &Rope,
     // First, remove any breaks in edited section.
     let mut builder = BreakBuilder::new();
     builder.add_no_break(newsize);
-    let edit_iv = Interval::new_open_closed(iv.start(), iv.end());
+    let edit_iv = Interval::new(iv.start(), iv.end());
     breaks.edit(edit_iv, builder.build());
     // At this point, breaks is aligned with text.
 
@@ -355,6 +355,6 @@ pub fn rewrap_width(breaks: &mut Breaks, text: &Rope,
     let new_breaks = compute_rewrap_width(text, width_cache, /* style_spans, */
                                           client, max_width, breaks,
                                           start, end);
-    let edit_iv = Interval::new_open_closed(start, start + new_breaks.len());
+    let edit_iv = Interval::new(start, start + new_breaks.len());
     breaks.edit(edit_iv, new_breaks);
 }

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -16,11 +16,10 @@
 
 use std::cmp::{min, max};
 use std::ops::Deref;
-use std::ops::Bound;
-use std::ops::RangeBounds;
 
 use index_set::remove_n_at;
 use xi_rope::delta::{Delta, Transformer};
+use xi_rope::interval::Interval;
 use xi_rope::rope::RopeInfo;
 
 /// A type representing horizontal measurements. This is currently in units
@@ -350,14 +349,9 @@ impl SelRegion {
     }
 }
 
-// Returns `[min..max)`
-impl<'a> RangeBounds<usize> for &'a SelRegion {
-    fn start_bound(&self) -> Bound<&usize> {
-        Bound::Included(min(&self.start, &self.end))
-    }
-    
-    fn end_bound(&self) -> Bound<&usize> {
-        Bound::Excluded(max(&self.start, &self.end))
+impl<'a> From<&'a SelRegion> for Interval {
+    fn from(src: &'a SelRegion) -> Interval {
+        Interval::new(src.min(), src.max())
     }
 }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -645,7 +645,7 @@ impl View {
                          style_spans: &Spans<Style>) -> Vec<isize>
     {
         let mut rendered_styles = Vec::new();
-        let style_spans = style_spans.subseq(Interval::new_closed_open(start, end));
+        let style_spans = style_spans.subseq(Interval::new(start, end));
 
         let mut ix = 0;
         // we add the special find highlights (1 to N) and selection (0) styles first.

--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -463,26 +463,26 @@ mod tests {
         c.buf_size = 2;
         c.contents = "oh".into();
 
-        let d = Delta::simple_edit(Interval::new_closed_open(0, 0), "yay".into(), c.contents.len());
+        let d = Delta::simple_edit(Interval::new(0, 0), "yay".into(), c.contents.len());
         c.update(Some(&d), d.new_document_len(), 1, 1);
         assert_eq!(&c.contents, "yayoh");
         assert_eq!(c.offset, 0);
 
-        let d = Delta::simple_edit(Interval::new_closed_open(0, 0), "ahh".into(), c.contents.len());
+        let d = Delta::simple_edit(Interval::new(0, 0), "ahh".into(), c.contents.len());
         c.update(Some(&d), d.new_document_len(), 1, 2);
 
         assert_eq!(&c.contents, "ahhyayoh");
         assert_eq!(c.offset, 0);
 
         let d =
-            Delta::simple_edit(Interval::new_closed_open(2, 2), "_oops_".into(), c.contents.len());
+            Delta::simple_edit(Interval::new(2, 2), "_oops_".into(), c.contents.len());
         assert_eq!(d.els.len(), 3);
         c.update(Some(&d), d.new_document_len(), 1, 3);
 
         assert_eq!(&c.contents, "ah_oops_hyayoh");
         assert_eq!(c.offset, 0);
 
-        let d = Delta::simple_edit(Interval::new_closed_open(9, 9), "fin".into(), c.contents.len());
+        let d = Delta::simple_edit(Interval::new(9, 9), "fin".into(), c.contents.len());
         c.update(Some(&d), d.new_document_len(), 1, 5);
 
         assert_eq!(&c.contents, "ah_oops_hfinyayoh");
@@ -559,7 +559,7 @@ mod tests {
         c.contents = "some".into();
         c.buf_size = 4;
         let d = Delta::simple_edit(
-            Interval::new_closed_open(0, 0),
+            Interval::new(0, 0),
             "two\nline\nbreaks".into(),
             c.contents.len(),
         );
@@ -569,7 +569,7 @@ mod tests {
         assert_eq!(c.line_offsets, vec![4, 9]);
 
         let d = Delta::simple_edit(
-            Interval::new_closed_open(4, 4),
+            Interval::new(4, 4),
             "one\nmore".into(),
             c.contents.len(),
         );
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(c.cached_offset_of_line(5), None);
 
         // delete a newline, and see that line_offsets is correctly updated
-        let delta = Delta::simple_edit(Interval::new_closed_open(3, 4), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new(3, 4), "".into(), c.buf_size);
         assert!(delta.is_simple_delete());
         c.update(Some(&delta), delta.new_document_len(), 3, 1);
         assert_eq!(&c.contents, "zerone\ntwo\ntri");
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(&c.contents, "zer\none\ntwo\ntri");
         assert_eq!(&c.line_offsets, &[4, 8, 12]);
 
-        let delta = Delta::simple_edit(Interval::new_closed_open(3, 4), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new(3, 4), "".into(), c.buf_size);
         assert!(delta.is_simple_delete());
         let (iv, _) = delta.summary();
         let start = iv.start();
@@ -674,7 +674,7 @@ mod tests {
         assert_eq!(&c.contents, "four\nlines!");
         assert_eq!(c.offset_of_line(&source, 3).unwrap(), 14);
         let d = Delta::simple_edit(
-            Interval::new_closed_open(10, 10),
+            Interval::new(10, 10),
             "ive nice\ns".into(),
             c.contents.len() + c.offset,
         );
@@ -703,7 +703,7 @@ mod tests {
         assert_eq!(c.first_line, 1);
         //assert_eq!(c.offset_of_line(&source, 2).unwrap(), 9);
         let d = Delta::simple_edit(
-            Interval::new_closed_open(6, 10),
+            Interval::new(6, 10),
             "".into(),
             c.contents.len() + c.offset,
         );
@@ -763,7 +763,7 @@ mod tests {
             four";
         let source = MockDataSource(base_document.into());
         let mut c = ChunkCache::default();
-        let delta = Delta::simple_edit(Interval::new_closed_open(0, 0), base_document.into(), 0);
+        let delta = Delta::simple_edit(Interval::new(0, 0), base_document.into(), 0);
         c.update(Some(&delta), base_document.len(), 4, 0);
         match c.get_line(&source, 4) {
             Err(Error::BadRequest) => (),
@@ -812,7 +812,7 @@ mod tests {
 
         let mut source = MockDataSource(base_document.into());
         let mut c = ChunkCache::default();
-        let delta = Delta::simple_edit(Interval::new_closed_open(0, 0), base_document.into(), 0);
+        let delta = Delta::simple_edit(Interval::new(0, 0), base_document.into(), 0);
 
         c.update(Some(&delta), base_document.len(), 4, 0);
         assert_eq!(c.get_line(&source, 0).unwrap(), "fn main() {\n");
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(c.get_line(&source, 2).unwrap(), "    let two = \"two\";\n");
         assert_eq!(c.get_line(&source, 3).unwrap(), "}");
 
-        let delta = Delta::simple_edit(Interval::new_closed_open(53, 54), "".into(), c.buf_size);
+        let delta = Delta::simple_edit(Interval::new(53, 54), "".into(), c.buf_size);
         c.update(Some(&delta), base_document.len() - 1, 3, 1);
         source.0 = edited_document.into();
         assert_eq!(c.get_line(&source, 0).unwrap(), "fn main() {\n");

--- a/rust/rope/Cargo.toml
+++ b/rust/rope/Cargo.toml
@@ -4,7 +4,7 @@ description = "A generic rope data structure built on top of B-Trees."
 license = "Apache-2.0"
 name = "xi-rope"
 repository = "https://github.com/google/xi-editor"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 bytecount = "0.3.1"

--- a/rust/rope/Cargo.toml
+++ b/rust/rope/Cargo.toml
@@ -4,7 +4,7 @@ description = "A generic rope data structure built on top of B-Trees."
 license = "Apache-2.0"
 name = "xi-rope"
 repository = "https://github.com/google/xi-editor"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 bytecount = "0.3.1"

--- a/rust/rope/docs/MetricsAndBoundaries.md
+++ b/rust/rope/docs/MetricsAndBoundaries.md
@@ -64,17 +64,3 @@ Here is an example where both leading and trailing boundaries are useful from th
 
 There current code needs to be fixed to support this. Probably the more systematic would be to explicitly request leading or trailing edge (likely by providing an additional explicit argument to the is_boundary, next, and prev methods of Cursor). Another approach is to bind the preference for leading or trailing boundary into the metric (this is closest to the way the code is currently structured), then require two separate instances of Metric to support the fast-path use case above.
 
-We probably also want to be more explicit in the convert_metrics method, which
-
-## Intervals
-One other confusing aspect to the code is the Interval struct and the fact that the endpoints can be open or closed. The best way to understand the intent is in terms of leading and trailing boundaries. Let's say that the interval represents some non-atomic metric, lines for example. An interval starting on a closed endpoint, or ending on an open one (both the most common cases) selects a trailing boundary. Conversely, starting on an open endpoint or ending on a closed one would select a leading boundary. Starting from the string "abc\ndef" and writing intervals in terms of the newline metric:
-
-[0, 1) -> "abc\n"
-(0, 1) -> "\n"
-[0, 1] -> "abc\ndef"
-(0, 1] -> "\ndef"
-In this framework, computing a substring of UTF-8 bytes based on code point indices would always be an open_closed interval.
-
-This is not supported in the current code, because it requires a way to calculate next and prev of the base metric, and the base metric is not directly accessible.
-
-When, as is most common, the interval is in base units, the distinction between leading and trailing boundaries can be ignored, and the flavor of the interval should default to closed_open.

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -47,7 +47,7 @@ impl Leaf for BreaksLeaf {
     fn push_maybe_split(&mut self, other: &BreaksLeaf, iv: Interval) -> Option<BreaksLeaf> {
         //eprintln!("push_maybe_split {:?} {:?} {}", self, other, iv);
         let (start, end) = iv.start_end();
-        let start_test = if iv.is_start_closed() { start } else { start + 1 };
+        let start_test = start + 1;
         for &v in &other.data {
             if start_test <= v && v <= end {
                 self.data.push(v - start + self.len);
@@ -254,7 +254,7 @@ mod tests {
         }
         for _ in 0..n {
             let len = node.len();
-            let empty_interval_at_end = Interval::new_open_closed(len, len);
+            let empty_interval_at_end = Interval::new(len, len);
             node.edit(empty_interval_at_end, testnode.clone());
         }
         node

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -47,9 +47,8 @@ impl Leaf for BreaksLeaf {
     fn push_maybe_split(&mut self, other: &BreaksLeaf, iv: Interval) -> Option<BreaksLeaf> {
         //eprintln!("push_maybe_split {:?} {:?} {}", self, other, iv);
         let (start, end) = iv.start_end();
-        let start_test = start + 1;
         for &v in &other.data {
-            if start_test <= v && v <= end {
+            if start < v && v <= end {
                 self.data.push(v - start + self.len);
             }
         }

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -178,7 +178,7 @@ impl Engine {
         let mut engine = Engine::empty();
         if initial_contents.len() > 0 {
             let first_rev = engine.get_head_rev_id().token();
-            let delta = Delta::simple_edit(Interval::new_closed_closed(0,0), initial_contents, 0);
+            let delta = Delta::simple_edit(Interval::new(0, 0), initial_contents, 0);
             engine.edit_rev(0, 0, first_rev, delta);
         }
         engine
@@ -832,20 +832,20 @@ mod tests {
 
     fn build_delta_1() -> Delta<RopeInfo> {
         let mut d_builder = Builder::new(TEST_STR.len());
-        d_builder.delete(Interval::new_closed_open(10, 36));
-        d_builder.replace(Interval::new_closed_open(39, 42), Rope::from("DEEF"));
-        d_builder.replace(Interval::new_closed_open(54, 54), Rope::from("999"));
-        d_builder.delete(Interval::new_closed_open(58, 61));
+        d_builder.delete(Interval::new(10, 36));
+        d_builder.replace(Interval::new(39, 42), Rope::from("DEEF"));
+        d_builder.replace(Interval::new(54, 54), Rope::from("999"));
+        d_builder.delete(Interval::new(58, 61));
         d_builder.build()
     }
 
     fn build_delta_2() -> Delta<RopeInfo> {
         let mut d_builder = Builder::new(TEST_STR.len());
-        d_builder.replace(Interval::new_closed_open(1, 3), Rope::from("!"));
-        d_builder.delete(Interval::new_closed_open(10, 36));
-        d_builder.replace(Interval::new_closed_open(42, 45), Rope::from("GI"));
-        d_builder.replace(Interval::new_closed_open(54, 54), Rope::from("888"));
-        d_builder.replace(Interval::new_closed_open(59, 60), Rope::from("HI"));
+        d_builder.replace(Interval::new(1, 3), Rope::from("!"));
+        d_builder.delete(Interval::new(10, 36));
+        d_builder.replace(Interval::new(42, 45), Rope::from("GI"));
+        d_builder.replace(Interval::new(54, 54), Rope::from("888"));
+        d_builder.replace(Interval::new(59, 60), Rope::from("HI"));
         d_builder.build()
     }
 
@@ -943,15 +943,15 @@ mod tests {
     #[test]
     fn undo_4() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("a"), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,0), Rope::from("a"), TEST_STR.len());
         let first_rev = engine.get_head_rev_id().token();
         engine.edit_rev(1, 1, first_rev, d1.clone());
         let new_head = engine.get_head_rev_id().token();
         engine.undo([1].iter().cloned().collect());
-        let d2 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("a"), TEST_STR.len()+1);
+        let d2 = Delta::simple_edit(Interval::new(0,0), Rope::from("a"), TEST_STR.len()+1);
         engine.edit_rev(1, 2, new_head, d2); // note this is based on d1 before, not the undo
         let new_head_2 = engine.get_head_rev_id().token();
-        let d3 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("b"), TEST_STR.len()+1);
+        let d3 = Delta::simple_edit(Interval::new(0,0), Rope::from("b"), TEST_STR.len()+1);
         engine.edit_rev(1, 3, new_head_2, d3);
         engine.undo([1,3].iter().cloned().collect());
         assert_eq!("a0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", String::from(engine.get_head()));
@@ -960,7 +960,7 @@ mod tests {
     #[test]
     fn undo_5() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,10), Rope::from(""), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,10), Rope::from(""), TEST_STR.len());
         let first_rev = engine.get_head_rev_id().token();
         engine.edit_rev(1, 1, first_rev, d1.clone());
         engine.edit_rev(1, 2, first_rev, d1.clone());
@@ -975,16 +975,16 @@ mod tests {
     #[test]
     fn gc() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("c"), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,0), Rope::from("c"), TEST_STR.len());
         let first_rev = engine.get_head_rev_id().token();
         engine.edit_rev(1, 1, first_rev, d1);
         let new_head = engine.get_head_rev_id().token();
         engine.undo([1].iter().cloned().collect());
-        let d2 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("a"), TEST_STR.len()+1);
+        let d2 = Delta::simple_edit(Interval::new(0,0), Rope::from("a"), TEST_STR.len()+1);
         engine.edit_rev(1, 2, new_head, d2);
         let gc : BTreeSet<usize> = [1].iter().cloned().collect();
         engine.gc(&gc);
-        let d3 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("b"), TEST_STR.len()+1);
+        let d3 = Delta::simple_edit(Interval::new(0,0), Rope::from("b"), TEST_STR.len()+1);
         let new_head_2 = engine.get_head_rev_id().token();
         engine.edit_rev(1, 3, new_head_2, d3);
         engine.undo([3].iter().cloned().collect());
@@ -998,7 +998,7 @@ mod tests {
 
         // insert `edits` letter "b"s in separate undo groups
         for i in 0..edits {
-            let d = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("b"), i);
+            let d = Delta::simple_edit(Interval::new(0,0), Rope::from("b"), i);
             let head = engine.get_head_rev_id().token();
             engine.edit_rev(1, i+1, head, d);
             if i >= max_undos {
@@ -1015,7 +1015,7 @@ mod tests {
         }
 
         // insert a character at the beginning
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,0), Rope::from("h"), engine.get_head().len());
+        let d1 = Delta::simple_edit(Interval::new(0,0), Rope::from("h"), engine.get_head().len());
         let head = engine.get_head_rev_id().token();
         engine.edit_rev(1, edits+1, head, d1);
 
@@ -1024,7 +1024,7 @@ mod tests {
 
         // insert character at end, when this test was added, it panic'd here
         let chars_left = (edits-max_undos)+1;
-        let d2 = Delta::simple_edit(Interval::new_closed_open(chars_left, chars_left), Rope::from("f"), engine.get_head().len());
+        let d2 = Delta::simple_edit(Interval::new(chars_left, chars_left), Rope::from("f"), engine.get_head().len());
         let head2 = engine.get_head_rev_id().token();
         engine.edit_rev(1, edits+1, head2, d2);
 
@@ -1051,7 +1051,7 @@ mod tests {
     #[test]
     fn gc_4() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,10), Rope::from(""), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,10), Rope::from(""), TEST_STR.len());
         let first_rev = engine.get_head_rev_id().token();
         engine.edit_rev(1, 1, first_rev, d1.clone());
         engine.edit_rev(1, 2, first_rev, d1.clone());
@@ -1065,7 +1065,7 @@ mod tests {
     #[test]
     fn gc_5() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,10), Rope::from(""), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,10), Rope::from(""), TEST_STR.len());
         let initial_rev = engine.get_head_rev_id().token();
         engine.undo([1].iter().cloned().collect());
         engine.edit_rev(1, 1, initial_rev, d1.clone());
@@ -1082,7 +1082,7 @@ mod tests {
     #[test]
     fn gc_6() {
         let mut engine = Engine::new(Rope::from(TEST_STR));
-        let d1 = Delta::simple_edit(Interval::new_closed_open(0,10), Rope::from(""), TEST_STR.len());
+        let d1 = Delta::simple_edit(Interval::new(0,10), Rope::from(""), TEST_STR.len());
         let initial_rev = engine.get_head_rev_id().token();
         engine.edit_rev(1, 1, initial_rev, d1.clone());
         engine.undo([1,2].iter().cloned().collect());

--- a/rust/rope/src/interval.rs
+++ b/rust/rope/src/interval.rs
@@ -34,29 +34,32 @@ pub struct Interval {
 }
 
 impl Interval {
+    /// Construct a new `Interval` representing the range [start..end).
+    /// It is an invariant that `start <= end`.
     pub fn new(start: usize, end: usize) -> Interval {
+        debug_assert!(start <= end);
         Interval {
             start,
             end,
         }
     }
 
-    #[deprecated(since="0.2.1", note="all intervals are now closed_open, use Interval::new")]
+    #[deprecated(since="0.3", note="all intervals are now closed_open, use Interval::new")]
     pub fn new_closed_open(start: usize, end: usize) -> Interval {
         Self::new(start, end)
     }
 
-    #[deprecated(since="0.2.1", note="all intervals are now closed_open")]
+    #[deprecated(since="0.3", note="all intervals are now closed_open")]
     pub fn new_open_closed(start: usize, end: usize) -> Interval {
         Self::new(start, end)
     }
 
-    #[deprecated(since="0.2.1", note="all intervals are now closed_open")]
+    #[deprecated(since="0.3", note="all intervals are now closed_open")]
     pub fn new_closed_closed(start: usize, end: usize) -> Interval {
         Self::new(start, end)
     }
 
-    #[deprecated(since="0.2.1", note="all intervals are now closed_open")]
+    #[deprecated(since="0.3", note="all intervals are now closed_open")]
     pub fn new_open_open(start: usize, end: usize) -> Interval {
         Self::new(start, end)
     }
@@ -144,6 +147,7 @@ impl Interval {
 
     // as above for Sub trait
     pub fn translate_neg(&self, amount: usize) -> Interval {
+        debug_assert!(self.start >= amount);
         Interval {
             start: self.start - amount,
             end: self.end - amount,
@@ -152,7 +156,7 @@ impl Interval {
 
     // insensitive to open or closed ends, just the size of the interior
     pub fn size(&self) -> usize {
-        self.end().saturating_sub(self.start())
+        self.end - self.start
     }
 }
 
@@ -301,6 +305,7 @@ mod tests {
     #[test]
     fn size() {
         assert_eq!(40, Interval::new(2, 42).size());
-        assert_eq!(0, Interval::new(1, 0).size());
+        assert_eq!(0, Interval::new(1, 1).size());
+        assert_eq!(1, Interval::new(1, 2).size());
     }
 }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -145,7 +145,7 @@ impl Subset {
     pub fn delete_from<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
         for (beg, end) in self.range_iter(CountMatcher::Zero) {
-            s.push_subseq(&mut b, Interval::new_closed_open(beg, end));
+            s.push_subseq(&mut b, Interval::new(beg, end));
         }
         b.build()
     }

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -480,15 +480,15 @@ impl Rope {
     /// Note: `edit` and `edit_str` may be merged, using traits.
     ///
     /// Time complexity: O(log n)
-    pub fn edit_str<T>(&mut self, range: T, new: &str) 
-        where T: RangeBounds<usize> 
+    pub fn edit_str<T>(&mut self, range: T, new: &str)
+        where T: RangeBounds<usize>
     {
         let (start, end) = self.extract_range(range);
 
         let mut b = TreeBuilder::new();
         // TODO: may make this method take the iv directly
-        let edit_iv = Interval::new_closed_open(start, end);
-        let self_iv = Interval::new_closed_closed(0, self.len());
+        let edit_iv = Interval::new(start, end);
+        let self_iv = Interval::new(0, self.len());
         self.push_subseq(&mut b, self_iv.prefix(edit_iv));
         b.push_str(new);
         self.push_subseq(&mut b, self_iv.suffix(edit_iv));
@@ -496,12 +496,12 @@ impl Rope {
     }
 
     /// Returns a new Rope with the contents of the provided range.
-    pub fn slice<T>(&self, range: T) -> Rope 
+    pub fn slice<T>(&self, range: T) -> Rope
         where T: RangeBounds<usize>
     {
         let (start, end) = self.extract_range(range);
 
-        let iv = Interval::new_closed_open(start, end);
+        let iv = Interval::new(start, end);
         self.subseq(iv)
     }
 

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -172,7 +172,7 @@ impl<T: Clone + Default> Spans<T> {
         let mut builder = SpansBuilder::new(new_end - new_start);
         for (iv, data) in self.iter() {
             let start = xform.transform(iv.start() + base_start, false) - new_start;
-            let end = xform.transform(iv.end() + base_start, true) - new_start;
+            let end = xform.transform(iv.end() + base_start, false) - new_start;
             if start < end {
                 let iv = Interval::new(start, end);
                 // TODO: could imagine using a move iterator and avoiding clone, but it's not easy.

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -22,7 +22,7 @@ use std::fmt;
 
 use tree::{Leaf, Node, NodeInfo, TreeBuilder, Cursor};
 use delta::{Delta, DeltaElement, Transformer};
-use interval::Interval;
+use interval::{Interval, IntervalBounds};
 
 const MIN_LEAF: usize = 32;
 const MAX_LEAF: usize = 64;
@@ -129,7 +129,8 @@ impl<T: Clone + Default> SpansBuilder<T> {
 
     // Precondition: spans must be added in nondecreasing start order.
     // Maybe take Span struct instead of separate iv, data args?
-    pub fn add_span(&mut self, iv: Interval, data: T) {
+    pub fn add_span<IV: IntervalBounds>(&mut self, iv: IV, data: T) {
+        let iv = iv.into_interval(self.total_len);
         if self.leaf.spans.len() == MAX_LEAF {
             let mut leaf = mem::replace(&mut self.leaf, SpansLeaf::default());
             leaf.len = iv.start() - self.len;

--- a/rust/rope/src/test_helpers.rs
+++ b/rust/rope/src/test_helpers.rs
@@ -81,11 +81,11 @@ pub fn parse_delta(s: &str) -> Delta<RopeInfo> {
         if c == '-' {
             i += 1;
         } else if c == '!' {
-            b.delete(Interval::new_closed_open(i,i+1));
+            b.delete(Interval::new(i,i+1));
             i += 1;
         } else {
             let inserted = format!("{}", c);
-            b.replace(Interval::new_closed_open(i,i), Rope::from(inserted));
+            b.replace(Interval::new(i,i), Rope::from(inserted));
         }
     }
 

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -54,7 +54,7 @@ pub trait NodeInfo: Clone {
     /// The interval covered by this node. The default impl is sufficient for most types,
     /// but interval trees may need to override it.
     fn interval(&self, len: usize) -> Interval {
-        Interval::new_closed_closed(0, len)
+        Interval::new(0, len)
     }
 }
 
@@ -280,7 +280,7 @@ impl<N: NodeInfo> Node<N> {
             let node1 = Arc::make_mut(&mut rope1.0);
             let leaf2 = rope2.get_leaf();
             if let NodeVal::Leaf(ref mut leaf1) = node1.val {
-                let leaf2_iv = Interval::new_closed_closed(0, leaf2.len());
+                let leaf2_iv = Interval::new(0, leaf2.len());
                 let new = leaf1.push_maybe_split(leaf2, leaf2_iv);
                 node1.len = leaf1.len();
                 node1.info = N::compute_info(leaf1);
@@ -381,7 +381,7 @@ impl<N: NodeInfo> Node<N> {
 
     pub fn edit(&mut self, iv: Interval, new: Node<N>) {
         let mut b = TreeBuilder::new();
-        let self_iv = Interval::new_closed_closed(0, self.len());
+        let self_iv = Interval::new(0, self.len());
         self.push_subseq(&mut b, self_iv.prefix(iv));
         b.push(new);
         self.push_subseq(&mut b, self_iv.suffix(iv));

--- a/rust/sample-plugin/src/main.rs
+++ b/rust/sample-plugin/src/main.rs
@@ -97,7 +97,7 @@ impl SamplePlugin {
         let new_text = view.get_line(line_nb)?[word_start..end_offset - line_start].to_uppercase();
         let buf_size = view.get_buf_size();
         let mut builder = EditBuilder::new(buf_size);
-        let iv = Interval::new_closed_open(line_start + word_start, end_offset);
+        let iv = Interval::new(line_start + word_start, end_offset);
         builder.replace(iv, new_text.into());
         view.edit(builder.build(), 0, false, true, "sample".into());
         Ok(())

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -234,7 +234,7 @@ impl<'a> Syntect<'a> {
 
                 let indent = self.indent_for_next_line(line, use_spaces, tab_size);
                 let ix = start + text.len();
-                let interval = Interval::new_closed_open(ix, ix);
+                let interval = Interval::new(ix, ix);
                 //TODO: view should have a `get_edit_builder` fn?
                 let mut builder = EditBuilder::new(buf_size);
                 builder.replace(interval, indent.into());


### PR DESCRIPTION
This is a step towards #914, removing the interval data type completely.
In order to simplify those changes, this changes the implementation of
Interval to only ever represent a closed-open range; this will make it easier
to reason about whatever changes are required to get wrapping and spans working
again.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
