### PR TITLE
Fix incorrect invalidation of breaks on rewrap

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -289,11 +289,7 @@ fn compute_rewrap_width(text: &Rope, width_cache: &mut WidthCache,
                         start: usize, end: usize) -> Breaks
 {
     let mut line_cursor = Cursor::new(&text, end);
-    let measure_end = if line_cursor.is_boundary::<LinesMetric>() {
-        end
-    } else {
-        line_cursor.next::<LinesMetric>().unwrap_or(text.len())
-    };
+    let measure_end = line_cursor.next::<LinesMetric>().unwrap_or(text.len());
     let mut ctx = RewrapCtx::new(text, /* style_spans, */ client, max_width,
                                  width_cache, start, measure_end);
     let mut builder = BreakBuilder::new();


### PR DESCRIPTION
This is a quick fix to the current width wrapping implementation,
patching over the major issue where an edit (delta) that ended on a byte
preceding a newline (and maybe also a soft break?) would cause the rest
of the document's breaks to be incorrectly invalidated.

This fix is likely papering over some fundamental problems with the
BreaksMetric, but it does at least fix the behaviour, and is fairly
cheap; the only consequence is that we will in some instances
recalculate an additional line's worth of breaks after some edits.

I intend to look at the breaks data structures more closely shortly, but
this seems worth a quick patch.

 ¯\\\_(ツ)\_/¯

fixes https://github.com/xi-editor/xi-mac/issues/301

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
