### PR TITLE
Deprecate Rope::edit_str

### DIFF
--- a/rust/rope/benches/edit.rs
+++ b/rust/rope/benches/edit.rs
@@ -68,11 +68,11 @@ fn benchmark_file_load_few_big_lines(b: &mut Bencher) {
 }
 
 #[bench]
-fn benchmark_char_insertion_one_line_edit_str(b: &mut Bencher) {
+fn benchmark_char_insertion_one_line_edit(b: &mut Bencher) {
     let mut text = Rope::from("b".repeat(100));
     let mut offset = 100;
     b.iter(|| {
-        text.edit_str(offset..=offset, "a");
+        text.edit(offset..=offset, "a");
         offset += 1;
     });
 }
@@ -83,7 +83,7 @@ fn benchmark_paste_into_line(b: &mut Bencher) {
     let insertion = "a".repeat(50);
     let mut offset = 100;
     b.iter(|| {
-        text.edit_str(offset..=offset, &insertion);
+        text.edit(offset..=offset, &insertion);
         offset += 150;
     });
 }
@@ -93,7 +93,7 @@ fn benchmark_insert_newline(b: &mut Bencher) {
     let mut text = Rope::from(build_few_big_lines(1_000_000));
     let mut offset = 1000;
     b.iter(|| {
-        text.edit_str(offset..=offset, "\n");
+        text.edit(offset..=offset, "\n");
         offset += 1001;
     });
 }
@@ -106,7 +106,7 @@ fn benchmark_overwrite_into_line(b: &mut Bencher) {
     b.iter(|| {
         // TODO: if the method runs too quickly, this may generate a fault
         // since there's an upper limit to how many times this can run.
-        text.edit_str(offset..=offset + 20, &insertion);
+        text.edit(offset..=offset + 20, &insertion);
         offset += 30;
     });
 }
@@ -118,7 +118,7 @@ fn benchmark_triangle_concat_inplace(b: &mut Bencher) {
     let insertion_len = insertion.len();
     let mut offset = 0;
     b.iter(|| {
-        text.edit_str(offset..=offset, &insertion);
+        text.edit(offset..=offset, &insertion);
         offset += insertion_len;
     });
 }

--- a/rust/rope/examples/ropetoy.rs
+++ b/rust/rope/examples/ropetoy.rs
@@ -20,16 +20,16 @@ use xi_rope::Rope;
 
 fn main() {
     let mut a = Rope::from("hello.");
-    a.edit_str(5..6, "!");
+    a.edit(5..6, "!");
     for i in 0..1000000 {
         let l = a.len();
-        a.edit_str(l..l, &(i.to_string() + "\n"));
+        a.edit(l..l, &(i.to_string() + "\n"));
     }
     let l = a.len();
     for s in a.clone().iter_chunks(1000..3000) {
         println!("chunk {:?}", s);
     }
-    a.edit_str(1000..l, "");
+    a.edit(1000..l, "");
     //a = a.subrange(0, 1000);
     println!("{:?}", String::from(a));
 }

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -85,7 +85,7 @@ const MAX_LEAF: usize = 1024;
 /// ```rust
 /// # use xi_rope::Rope;
 /// let mut a = Rope::from("hello world");
-/// a.edit_str(1..9, "era");
+/// a.edit(1..9, "era");
 /// assert_eq!("herald", String::from(a));
 /// ```
 pub type Rope = Node<RopeInfo>;
@@ -470,6 +470,7 @@ impl Rope {
     /// Edit the string, replacing the byte range [`start`..`end`] with `new`.
     ///
     /// Time complexity: O(log n)
+    #[deprecated(since = "0.3", note = "Use Rope::edit instead")]
     pub fn edit_str<T: IntervalBounds>(&mut self, iv: T, new: &str) {
         self.edit(iv, new)
     }
@@ -890,7 +891,7 @@ mod tests {
     #[test]
     fn replace_small() {
         let mut a = Rope::from("hello world");
-        a.edit_str(1..9, "era");
+        a.edit(1..9, "era");
         assert_eq!("herald", String::from(a));
     }
 


### PR DESCRIPTION
This is unnecessary as of a change I snuck into #941; and since we've done a version bump but haven't done a release this feels like a good time to get rid of it.