### PR TITLE
Only run CI rustfmt check on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
   - export RUST_BACKTRACE=1
   - RUSTFLAGS="-D warnings" cargo check --all || exit
   - cargo test --all || exit
-  - cargo fmt --all -- --check
+  - if [ "$TRAVIS_RUST_VERSION" = '1.29.2' ]; then cargo fmt --all -- --check; fi


### PR DESCRIPTION
Rustfmt will always fail on nightly, because there are different rules.