### PR TITLE
Reduce memory use of triangle_concat benchmark

### DIFF
--- a/rust/rope/benches/edit.rs
+++ b/rust/rope/benches/edit.rs
@@ -114,7 +114,7 @@ fn benchmark_overwrite_into_line(b: &mut Bencher) {
 #[bench]
 fn benchmark_triangle_concat_inplace(b: &mut Bencher) {
     let mut text = Rope::from("");
-    let insertion = build_triangle(10_000);
+    let insertion = build_triangle(3000);
     let insertion_len = insertion.len();
     let mut offset = 0;
     b.iter(|| {


### PR DESCRIPTION
This was using something like 16GB of ram, and was crashing on an older
computer I sometimes use for testing.
