### PR TITLE
Atomic Save

### DIFF
--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -188,9 +188,10 @@ where
 fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result<()> {
     use std::fs;
 
-    let tmp_extension = path.extension()
+    let tmp_extension = path
+        .extension()
         .and_then(|extension| extension.to_str())
-        .map_or_else(|| "swp".to_string(),|extension| format!("{}.swp", extension));
+        .map_or_else(|| "swp".to_string(), |extension| format!("{}.swp", extension));
     let tmp_path = &path.with_extension(tmp_extension);
 
     let mut f = File::create(tmp_path)?;

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -191,7 +191,7 @@ fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result
     let tmp_extension = path
         .extension()
         .and_then(|extension| extension.to_str())
-        .map_or_else(|| "swp".to_string(), |extension| format!("{}.swp", extension));
+        .map_or_else(|| "swp".to_string(), |extension| extension.to_string() + ".swp");
     let tmp_path = &path.with_extension(tmp_extension);
 
     let mut f = File::create(tmp_path)?;

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -186,7 +186,14 @@ where
 }
 
 fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result<()> {
-    let mut f = File::create(path)?;
+    use std::fs;
+
+    let tmp_extension = path.extension()
+        .and_then(|extension| extension.to_str())
+        .map_or_else(|| "swp".to_string(),|extension| format!("{}.swp", extension));
+    let tmp_path = &path.with_extension(tmp_extension);
+
+    let mut f = File::create(tmp_path)?;
     match encoding {
         CharacterEncoding::Utf8WithBom => f.write_all(UTF8_BOM.as_bytes())?,
         CharacterEncoding::Utf8 => (),
@@ -195,6 +202,9 @@ fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result
     for chunk in text.iter_chunks(..text.len()) {
         f.write_all(chunk.as_bytes())?;
     }
+
+    fs::rename(tmp_path, path)?;
+
     Ok(())
 }
 

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -16,7 +16,8 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::fs::File;
+use std::ffi::OsString;
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::str;
@@ -186,12 +187,13 @@ where
 }
 
 fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result<()> {
-    use std::fs;
-
     let tmp_extension = path
         .extension()
-        .and_then(|extension| extension.to_str()?.to_string().into())
-        .map_or_else(|| "swp".to_string(), |extension| extension + ".swp");
+        .map_or_else(|| OsString::from("swp"), |ext| {
+            let mut ext = ext.to_os_string();
+            ext.push(".swp");
+            ext
+        });
     let tmp_path = &path.with_extension(tmp_extension);
 
     let mut f = File::create(tmp_path)?;

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -15,8 +15,8 @@
 //! Interactions with the file system.
 
 use std::collections::HashMap;
-use std::fmt;
 use std::ffi::OsString;
+use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -187,13 +187,14 @@ where
 }
 
 fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result<()> {
-    let tmp_extension = path
-        .extension()
-        .map_or_else(|| OsString::from("swp"), |ext| {
+    let tmp_extension = path.extension().map_or_else(
+        || OsString::from("swp"),
+        |ext| {
             let mut ext = ext.to_os_string();
             ext.push(".swp");
             ext
-        });
+        },
+    );
     let tmp_path = &path.with_extension(tmp_extension);
 
     let mut f = File::create(tmp_path)?;

--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -190,8 +190,8 @@ fn try_save(path: &Path, text: &Rope, encoding: CharacterEncoding) -> io::Result
 
     let tmp_extension = path
         .extension()
-        .and_then(|extension| extension.to_str())
-        .map_or_else(|| "swp".to_string(), |extension| extension.to_string() + ".swp");
+        .and_then(|extension| extension.to_str()?.to_string().into())
+        .map_or_else(|| "swp".to_string(), |extension| extension + ".swp");
     let tmp_path = &path.with_extension(tmp_extension);
 
     let mut f = File::create(tmp_path)?;

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -392,7 +392,9 @@ impl CoreState {
         let ed = &self.editors[&buffer_id];
 
         if let Err(e) = self.file_manager.save(path, ed.borrow().get_buffer(), buffer_id) {
-            self.peer.alert(e.to_string());
+            let error_message = e.to_string();
+            error!("File error: {:?}", error_message);
+            self.peer.alert(error_message);
             return;
         }
 


### PR DESCRIPTION
## Summary
We don't want to accidentally corrupt user data while trying to _save_ their data, so we should be a little more defensive in that process.

I took the approach to save the new content to a swapfile before overwriting the original. Currently the swapfile is written to the same directory that the final final will be written to, but we can change that to a temp directory or some xi specific directory if we want.

## Related Issues
Resolves #918

## Checklist
- [x] Test
- [ ] Review

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
