### PR TITLE
Add surrounding_pairs option to xi-core-lib; add InsertDrift

### DIFF
--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -26,3 +26,10 @@ wrap_width = 0
 word_wrap = false
 
 autodetect_whitespace = true
+
+surrounding_pairs = [
+  ["\"", "\""],
+  ["'", "'"],
+  ["{", "}"],
+  ["[", "]"],
+]

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -169,6 +169,7 @@ pub struct BufferItems {
     pub wrap_width: usize,
     pub word_wrap: bool,
     pub autodetect_whitespace: bool,
+    pub surrounding_pairs: Vec<(String, String)>,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -17,7 +17,7 @@
 use std::cmp::{max, min};
 
 use regex::{Regex, RegexBuilder};
-use selection::{SelRegion, Selection};
+use selection::{InsertDrift, SelRegion, Selection};
 use view::View;
 use word_boundaries::WordCursor;
 use xi_rope::delta::DeltaRegion;
@@ -144,7 +144,7 @@ impl Find {
                 self.occurrences.delete_range(old_offset, old_offset + len, false);
             }
 
-            self.occurrences = self.occurrences.apply_delta(delta, false, false);
+            self.occurrences = self.occurrences.apply_delta(delta, false, InsertDrift::Default);
 
             // invalidate occurrences around insert positions
             for DeltaRegion { new_offset, len, .. } in delta.iter_inserts() {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -25,7 +25,7 @@ use line_cache_shadow::{self, LineCacheShadow, RenderPlan, RenderTactic};
 use linewrap;
 use movement::{region_movement, selection_movement, Movement};
 use rpc::{FindQuery, GestureType, MouseAction, SelectionModifier};
-use selection::{Affinity, SelRegion, Selection};
+use selection::{Affinity, InsertDrift, SelRegion, Selection};
 use styles::{Style, ThemeStyleMap};
 use tabs::{BufferId, Counter, ViewId};
 use width_cache::WidthCache;
@@ -953,7 +953,7 @@ impl View {
         delta: &RopeDelta,
         client: &Client,
         width_cache: &mut WidthCache,
-        keep_selections: bool,
+        drift: InsertDrift,
     ) {
         let (iv, new_len) = delta.summary();
         if let Some(breaks) = self.breaks.as_mut() {
@@ -988,7 +988,7 @@ impl View {
 
         // Note: for committing plugin edits, we probably want to know the priority
         // of the delta so we can set the cursor before or after the edit, as needed.
-        let new_sel = self.selection.apply_delta(delta, true, keep_selections);
+        let new_sel = self.selection.apply_delta(delta, true, drift);
         self.set_selection_for_edit(text, new_sel);
     }
 


### PR DESCRIPTION
## Summary

This adds the surrounding_pairs option. If all selections are regions (and not carets) and the user types a first half of a surrounding pair, then we will surround the selection with the surrounding pair instead of replacing the selection. This config option can be edited on a per- language basis.

This change also adds `InsertDrift` as a replacement for the old keep_selections option. The keep_selections bool, if true, overrode the 'after' property, ensuring that inserts 'drifted' to the side of a cursor that was inside a selection. This change keeps that same functionality, but adds the option to have inserts 'drift' to the outside of a selection instead.

It's not ~fully tested or complete, but the functionality works, and I thought I'd submit this WIP just to see if this is the right approach before investing more time into it?

## Related Issues
A part of several tasks within #647

## Checklist

- [x] Still need to add tests

## Review Checklist

- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
