### PR TITLE
Add get_region to plugin lib

### DIFF
--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -41,6 +41,7 @@ use std::path::Path;
 
 use xi_core::plugin_rpc::{GetDataResponse, TextUnit};
 use xi_core::{ConfigTable, LanguageId};
+use xi_rope::interval::IntervalBounds;
 use xi_rope::RopeDelta;
 use xi_rpc::{ReadError, RpcLoop};
 
@@ -85,6 +86,19 @@ pub trait Cache {
     ///
     /// [`DataSource`]: trait.DataSource.html
     fn get_line<DS: DataSource>(&mut self, source: &DS, line_num: usize) -> Result<&str, Error>;
+
+    /// Returns the specified region of the buffer. Returns an `Err(_)` if
+    /// there is a problem connecting to the peer, or if the requested line
+    /// is out of bounds.
+    ///
+    /// The `source` argument is some type that implements [`DataSource`]; in
+    /// the general case this is backed by the remote peer.
+    ///
+    /// [`DataSource`]: trait.DataSource.html
+    fn get_region<DS, I>(&mut self, source: &DS, interval: I) -> Result<&str, Error>
+    where
+        DS: DataSource,
+        I: IntervalBounds;
 
     /// Returns the entire contents of the remote document, fetching as needed.
     fn get_document<DS: DataSource>(&mut self, source: &DS) -> Result<String, Error>;

--- a/rust/plugin-lib/src/state_cache.rs
+++ b/rust/plugin-lib/src/state_cache.rs
@@ -17,6 +17,7 @@
 use bytecount;
 use rand::{thread_rng, Rng};
 
+use xi_rope::interval::IntervalBounds;
 use xi_rope::{LinesMetric, RopeDelta};
 use xi_trace::trace_block;
 
@@ -54,6 +55,14 @@ impl<S: Clone + Default> Cache for StateCache<S> {
 
     fn get_line<DS: DataSource>(&mut self, source: &DS, line_num: usize) -> Result<&str, Error> {
         self.buf_cache.get_line(source, line_num)
+    }
+
+    fn get_region<DS, I>(&mut self, source: &DS, interval: I) -> Result<&str, Error>
+    where
+        DS: DataSource,
+        I: IntervalBounds,
+    {
+        self.buf_cache.get_region(source, interval)
     }
 
     fn get_document<DS: DataSource>(&mut self, source: &DS) -> Result<String, Error> {

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use xi_core::plugin_rpc::{GetDataResponse, PluginBufferInfo, PluginEdit, ScopeSpan, TextUnit};
 use xi_core::{BufferConfig, ConfigTable, LanguageId, PluginPid, ViewId};
+use xi_rope::interval::IntervalBounds;
 use xi_rope::RopeDelta;
 use xi_trace::trace_block;
 
@@ -122,6 +123,12 @@ impl<C: Cache> View<C> {
     pub fn get_line(&mut self, line_num: usize) -> Result<&str, Error> {
         let ctx = self.make_ctx();
         self.cache.get_line(&ctx, line_num)
+    }
+
+    /// Returns a region of the view's buffer.
+    pub fn get_region<I: IntervalBounds>(&mut self, interval: I) -> Result<&str, Error> {
+        let ctx = self.make_ctx();
+        self.cache.get_region(&ctx, interval)
     }
 
     pub fn get_document(&mut self) -> Result<String, Error> {


### PR DESCRIPTION
I'm using this in the auto-indent work but it makes sense as a standalone patch.

-----------
This is a convenience method for more easily accessing slices of the
underlying buffer.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
