### PR TITLE
Simple syntect-based autoindent

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -946,8 +946,8 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "3.0.1"
-source = "git+https://github.com/cmyr/syntect.git?branch=feature/metadata#3dd6f52817494ee9a8ee53bc3527a658821f8bb0"
+version = "3.0.2"
+source = "git+https://github.com/trishume/syntect.git#b82ee3195979d3d34352593d182bce52f102064b"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1302,7 +1302,7 @@ version = "0.0.0"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 3.0.1 (git+https://github.com/cmyr/syntect.git?branch=feature/metadata)",
+ "syntect 3.0.2 (git+https://github.com/trishume/syntect.git)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
@@ -1463,7 +1463,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum syntect 3.0.1 (git+https://github.com/cmyr/syntect.git?branch=feature/metadata)" = "<none>"
+"checksum syntect 3.0.2 (git+https://github.com/trishume/syntect.git)" = "<none>"
 "checksum syntect 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e02dd9df97a68a2d005ace28ff24c610abfc3ce17afcfdb22a077645dabb599a"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -30,7 +30,7 @@ name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "nodrop"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -946,8 +946,8 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "3.0.1"
+source = "git+https://github.com/cmyr/syntect.git?branch=feature/metadata#3dd6f52817494ee9a8ee53bc3527a658821f8bb0"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -958,6 +958,23 @@ dependencies = [
  "onig 4.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntect"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1285,7 +1302,7 @@ version = "0.0.0"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 3.0.1 (git+https://github.com/cmyr/syntect.git?branch=feature/metadata)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",
  "xi-plugin-lib 0.1.0",
@@ -1401,7 +1418,7 @@ dependencies = [
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum notify 4.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "873ecfd8c174964ae30f401329d140142312c8e5590719cf1199d5f1717d8078"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
@@ -1446,6 +1463,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum syntect 3.0.1 (git+https://github.com/cmyr/syntect.git?branch=feature/metadata)" = "<none>"
 "checksum syntect 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e02dd9df97a68a2d005ace28ff24c610abfc3ce17afcfdb22a077645dabb599a"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -26,7 +26,7 @@ font_face = "Inconsolata"
 font_size = 14
 
 # Automatically match current indentation level on newline.
-auto_indent = false
+auto_indent = true
 
 # Allow scrolling past the last line of a document.
 scroll_past_end = false

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -17,7 +17,7 @@ font_size = 14
 
 line_ending = "\n"
 
-auto_indent = false
+auto_indent = true
 
 scroll_past_end = false
 

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -199,6 +199,7 @@ pub enum Error {
     RpcError(xi_rpc::Error),
     WrongReturnType,
     BadRequest,
+    PeerDisconnect,
     // Just used in tests
     Other(String),
 }

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -14,9 +14,10 @@ serde_derive = "1.0"
 toml = "0.4"
 
 [dependencies.syntect]
-version = "3.0"
+git = "https://github.com/cmyr/syntect.git"
+branch = "feature/metadata"
 default-features = false
-features = ["parsing", "assets","dump-load-rs"]
+features = ["parsing", "assets","dump-load-rs", "metadata"]
 
 [dependencies.xi-plugin-lib]
 path = "../plugin-lib"

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -14,8 +14,8 @@ serde_derive = "1.0"
 toml = "0.4"
 
 [dependencies.syntect]
-git = "https://github.com/cmyr/syntect.git"
-branch = "feature/metadata"
+git = "https://github.com/trishume/syntect.git"
+branch = "master"
 default-features = false
 features = ["parsing", "assets","dump-load-rs", "metadata"]
 

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -274,20 +274,14 @@ impl<'a> Syntect<'a> {
             return Ok(());
         }
         let prev_line = self.previous_nonblank_line(view, line)?;
-        let indent_level = self.indent_level_of_line(view, prev_line);
-        let increase = self.test_increase(view, prev_line + 1)?;
         let decrease = self.test_decrease(view, line)?;
-        let indent_level = match (increase, decrease) {
-            (true, false) => indent_level + tab_size,
-            (false, true) => indent_level.saturating_sub(tab_size),
-            _ => indent_level,
-        };
-
-        if indent_level != current_indent {
-            self.set_indent(view, line, indent_level)
-        } else {
-            Ok(())
+        if decrease {
+            let indent_level = self.indent_level_of_line(view, prev_line).saturating_sub(tab_size);
+            if indent_level != current_indent {
+                return self.set_indent(view, line, indent_level);
+            }
         }
+        Ok(())
     }
 
     fn set_indent(&self, view: &mut MyView, line: usize, level: usize) -> Result<(), Error> {


### PR DESCRIPTION
This adds support for basic autoindent, for languages supported by
syntect, through the syntect-plugin.

This implementation is not quite as fancy as Sublime's; we only use the
two most basic regex patterns, for 'increase next' and 'decrease
current' indentation level.

It is, however, actual honest-to-goodness syntax-aware auto-indent,
which is a step in the right direction.

Closes #424
Progress on #937

-----------


This patch has a sibling at https://github.com/trishume/syntect/pull/223; currently this is pointing to my syntect fork, so it shouldn't be merged before that does. In the meantime, anyone who is interested is encouraged to play around with this; I've only really tested it in rust any python, and not extensively in either case.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.