### PR TITLE
Fix off-by-one in plugin cache update logic

### DIFF
--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -322,16 +322,15 @@ impl ChunkCache {
         let start = iv.start();
         let end = iv.end();
         // we only apply the delta if it is a simple edit, which
-        // begins in the interior of our chunk.
+        // begins inside or immediately following our chunk.
         // - If it begins _before_ our chunk, we are likely going to
         // want to fetch the edited region, which will reset our state;
-        // - If it begins _after_ our chunk, it has no effect on our state;
         // - If it's a complex edit the logic is tricky, and this should
         // be rare enough we can afford to discard.
         // The one 'complex edit' we should probably be handling is
         // the replacement of a single range. This could be a new
         // convenience method on `Delta`?
-        if start < self.offset || start >= self.offset + self.contents.len() {
+        if start < self.offset || start > self.offset + self.contents.len() {
             true
         } else if delta.is_simple_delete() {
             self.simple_delete(start, end);


### PR DESCRIPTION
We were in correctly declining to apply a delta that was an append at
the end of file, which caused us to unnecessarily invalidate our cache.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
