### PR TITLE
Replace references to IRC with Zulip

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,14 +23,14 @@ follow the [Code of Conduct](https://github.com/xi-editor/xi-editor/blob/master/
 ### Very first steps
 
 Not sure where to start? If you haven't already, take a look at the
-[docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better
-sense of the project. Read through some issues and some open PRs, to
-get a sense for the habits of existing contributors. Drop by the #xi
-channel on [Zulip](https://xi.zulipchat.com) to follow
-ongoing discussions or ask questions. Clone the repos you're
-interested in, and make sure you can build and run the tests. If you
-can't, open an issue, and someone will try to help. Once you're up and
-running, there are a a number of ways to participate:
+[docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better sense of
+the project. Read through some issues and some open PRs, to get a sense for the
+habits of existing contributors. Drop by the #xi-editor stream on
+[Zulip](https://xi.zulipchat.com) (anyone with a Github account can easily
+signup), or the #xi channel on irc.mozilla.org, to follow ongoing discussions or
+ask questions. Clone the repos you're interested in, and make sure you can build
+and run the tests. If you can't, open an issue, and someone will try to help.
+Once you're up and running, there are a a number of ways to participate:
 
 ### Opening issues
 
@@ -93,7 +93,7 @@ issues that are labeled
 [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and/or
 [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy)
 are good places to start. If you can't find anything there, feel free to ask
-on Zulip, or play around with the editor and try to identify something that
+on Zulip or IRC, or play around with the editor and try to identify something that
 _you_ think is missing.
 
 ### Before you start work

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,11 +22,11 @@ follow the [Code of Conduct](https://github.com/xi-editor/xi-editor/blob/master/
 
 ### Very first steps
 
-Not sure where to start? If you haven't already, take a look at the 
+Not sure where to start? If you haven't already, take a look at the
 [docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better
 sense of the project. Read through some issues and some open PRs, to
 get a sense for the habits of existing contributors. Drop by the #xi
-channel on [irc.mozilla.org](https://mozilla.logbot.info/xi) to follow
+channel on [Zulip](https://xi.zulipchat.com) to follow
 ongoing discussions or ask questions. Clone the repos you're
 interested in, and make sure you can build and run the tests. If you
 can't, open an issue, and someone will try to help. Once you're up and
@@ -44,11 +44,11 @@ and/or examples of how this feature is used in other editors.
 #### Before you open an issue
 
 Before opening an issue, **try to identify where the issue belongs**.
-Is it a problem with the frontend or with core? The frontend is 
+Is it a problem with the frontend or with core? The frontend is
 responsible for drawing windows and UI, and handling events; the core
 is responsible for most everything else. Issues with the frontend
 should be opened in that frontend's repository, and issues with
-core should be opened in the 
+core should be opened in the
 [xi-editor](https://github.com/xi-editor/xi-editor/issues) repo.
 
 Finally, before opening an issue, **use github's search bar** to make
@@ -89,23 +89,23 @@ reviews, see [code review process](#review-process).
 
 If you're looking for something to work on, a good first step is to browse
 the [issues](https://github.com/xi-editor/xi-editor/issues). Specifically,
-issues that are labeled 
+issues that are labeled
 [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and/or
 [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy)
 are good places to start. If you can't find anything there, feel free to ask
-on IRC, or play around with the editor and try to identify something that
+on Zulip, or play around with the editor and try to identify something that
 _you_ think is missing.
 
 ### Before you start work
 
 Before starting to work on an issue, consider the following:
-    
+
 - _Is it a bugfix or small change?_ If you notice a small bug somewhere,
  and you believe you have a fix, feel free to open a pull request directly.
 
 - _Is it a feature?_ If you have an idea for a new editor feature that is
  along the lines of something that already exists (for instance, adding a
- new command to reverse the letters in a selected region) _consider_ 
+ new command to reverse the letters in a selected region) _consider_
  opening a short issue beforehand, describing the feature you have in mind.
  Other contributors might be able to identify possible issues or
  refinements. This isn't _necessary_, but it might end up saving you work,
@@ -113,18 +113,18 @@ Before starting to work on an issue, consider the following:
  which feels good.
 
 - _Is it a major feature, affecting for instance the behaviour or appearance
- of a frontend, or the API or architecture of core?_ Before working on a 
+ of a frontend, or the API or architecture of core?_ Before working on a
  large change, please open a discussion/proposal issue. This should describe
- the problem you're trying to solve, and the approach you're considering; 
- think of this as a 'lite' version of Rust's 
- [RFC](https://github.com/rust-lang/rfcs) process. 
+ the problem you're trying to solve, and the approach you're considering;
+ think of this as a 'lite' version of Rust's
+ [RFC](https://github.com/rust-lang/rfcs) process.
 
 
 ### Before you open your PR
 
-Before pressing the 'Create pull request' button, 
+Before pressing the 'Create pull request' button,
 
-- _Run the tests_. It's easy to accidentally break something with even a small 
+- _Run the tests_. It's easy to accidentally break something with even a small
  change, so always run the tests locally before submitting (or updating) a PR.
  You can run all checks locally with the `xi-editor/rust/run_all_checks`. script.
 
@@ -135,18 +135,18 @@ Before pressing the 'Create pull request' button,
  If your change changes some behaviour, how might it be tested?
 
 - ***Be your own first reviewer***. On the page where you enter your message,
- you have a final opportunity to see your PR _as it will be seen by your 
+ you have a final opportunity to see your PR _as it will be seen by your
  reviewers_. This is a great opportunity to give it one last review, yourself.
- Imagine that it is someone else's work, that you're reviewing: what comments 
- would you have? If you spot a typo or a problem, you can push an update in 
+ Imagine that it is someone else's work, that you're reviewing: what comments
+ would you have? If you spot a typo or a problem, you can push an update in
  place, without losing your PR message or other state.
 
-- _Add yourself to the AUTHORS file_. If this is your first substantive pull 
+- _Add yourself to the AUTHORS file_. If this is your first substantive pull
 request in this repo, feel free to add yourself to the AUTHORS file.
 
 ### Review process
 
-Every non-trivial pull request goes through review. Everyone is welcome to 
+Every non-trivial pull request goes through review. Everyone is welcome to
 participate in review; review is an excellent time to ask questions about
 code or design decisions that you don't understand.
 
@@ -156,7 +156,7 @@ commit rights to the repo in question; larger changes (changes which add a
 feature, or significantly change behaviour or API) should also be approved by
 a maintainer.
 
-Before being merged, a change must pass 
+Before being merged, a change must pass
 [CI](https://en.wikipedia.org/wiki/Continuous_integration).
 
 #### Responsibilites of the approving reviewer
@@ -169,11 +169,11 @@ and overall coding style of the relevant repo
 - are ready and able to help resolve any problems that may be introduced by
 merging the change.
 
-If a PR is made by a contributor who has write access to the repo in question, 
-they are responsible for merging/rebasing the PR after it has been approved; 
+If a PR is made by a contributor who has write access to the repo in question,
+they are responsible for merging/rebasing the PR after it has been approved;
 otherwise it will be merged by the reviewer.
 
-If a patch adds or modifies behaviour that is observable in the client, 
+If a patch adds or modifies behaviour that is observable in the client,
 the reviewer should build the patch and verify that it works as expected.
 
 ### After submitting your change
@@ -189,7 +189,7 @@ type of feedback you might expect.
 _Patience_. As a general goal, we try to respond to all pull requests
 within a few days, and to do preliminary review within a week, but we
 don't always succeed. If you've opened a PR and haven't heard from
-anyone, feel free to comment on it, or stop by the IRC channel, to ask
+anyone, feel free to comment on it, or stop by the Zulip channel, to ask
 if anyone has had a chance to take a look. It's very possible that it's
 been lost in the shuffle.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,8 @@
 - [ ] I have studied the documentation.
 
 <!---
-Please ensure the issue meets these requirements. If you are not sure, questions are welcome on the #xi chatroom on irc.mozilla.org.
+Please ensure the issue meets these requirements. If you are not sure, questions
+are welcome on the #xi-editor channel on https://xi.zulipchat.com.
 --->
 ## Details
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 **Contact**: [mods@xi-editor.io](mailto:mods@xi-editor.io)
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
-* On Zulip, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* On chat platforms (like Zulip and IRC), please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
@@ -36,8 +36,6 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official xi-editor venues,
-including the #xi-editor Zulip channel and the repositories under the xi-editor
-organization.
+The enforcement policies listed above apply to all official xi-editor venues, including Zulip, the #xi channel on IRC, and the repositories under the xi-editor organization.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 **Contact**: [mods@xi-editor.io](mailto:mods@xi-editor.io)
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
-* On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* On Zulip, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
@@ -18,8 +18,10 @@ The xi-editor project follows the Rust Code of Conduct, reproduced below.
 ## Moderation
 
 
-These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact
-a mod (on IRC) or a maintainer (on Github). To contact a moderator by email, use [mods@xi-editor.io](mailto:mods@xi-editor.io).
+These are the policies for upholding our community's standards of conduct. If
+you feel that a thread needs moderation, please contact a maintainer on Github.
+To contact a moderator by email, use
+[mods@xi-editor.io](mailto:mods@xi-editor.io).
 
 1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
@@ -34,7 +36,8 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official xi-editor venues, including the #xi irc channel and the repositories under the
-xi-editor organization.
+The enforcement policies listed above apply to all official xi-editor venues,
+including the #xi-editor Zulip channel and the repositories under the xi-editor
+organization.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/README.md
+++ b/README.md
@@ -167,5 +167,6 @@ We gladly accept contributions via GitHub pull requests. Please see
 [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more details.
 
 If you are interested in contributing but not sure where to start, there is an
-active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also a
-subreddit at [/r/xi_editor](https://www.reddit.com/r/xi_editor/).
+active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also
+a #xi channel on irc.mozilla.org. Finally, there is a subreddit at
+[/r/xi_editor](https://www.reddit.com/r/xi_editor/).

--- a/README.md
+++ b/README.md
@@ -166,6 +166,6 @@ This project is licensed under the Apache 2 [license](LICENSE).
 We gladly accept contributions via GitHub pull requests. Please see
 [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more details.
 
-If you are interested in contributing but not sure where to start, there is
-an active IRC channel at #xi on irc.mozilla.org. There is also a subreddit at
-[/r/xi_editor](https://www.reddit.com/r/xi_editor/).
+If you are interested in contributing but not sure where to start, there is an
+active Zulip channel at #xi-editor on https://xi.zulipchat.com. There is also a
+subreddit at [/r/xi_editor](https://www.reddit.com/r/xi_editor/).

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -31,8 +31,8 @@ follow the [Code of Conduct](https://github.com/xi-editor/xi-editor/blob/master/
 Not sure where to start? If you haven't already, take a look at the
 [docs](http://xi-editor.github.io/xi-editor/docs.html) to get a better
 sense of the project. Read through some issues and some open PRs, to
-get a sense for the habits of existing contributors. Drop by the #xi
-channel on [irc.mozilla.org](https://mozilla.logbot.info/xi) to follow
+get a sense for the habits of existing contributors. Drop by the #xi-editor
+channel on [Zulip](https://xi.zulipchat.com) to follow
 ongoing discussions or ask questions. Clone the repos you're
 interested in, and make sure you can build and run the tests. If you
 can't, open an issue, and someone will try to help. Once you're up and
@@ -99,7 +99,7 @@ issues that are labeled
 [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and/or
 [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy)
 are good places to start. If you can't find anything there, feel free to ask
-on IRC, or play around with the editor and try to identify something that
+on Zulip, or play around with the editor and try to identify something that
 _you_ think is missing.
 
 ### Before you start work
@@ -195,7 +195,7 @@ type of feedback you might expect.
 _Patience_. As a general goal, we try to respond to all pull requests
 within a few days, and to do preliminary review within a week, but we
 don't always succeed. If you've opened a PR and haven't heard from
-anyone, feel free to comment on it, or stop by the IRC channel, to ask
+anyone, feel free to comment on it, or stop by the Zulip channel, to ask
 if anyone has had a chance to take a look. It's very possible that it's
 been lost in the shuffle.
 

--- a/docs/gsoc.md
+++ b/docs/gsoc.md
@@ -6,7 +6,7 @@ is_site_nav_category: true
 site_nav_category: gsoc
 ---
 
-Please, use the suggested [proposal template](gsoc-template.html) when applying. Check out [GSoC guides](https://google.github.io/gsocguides/student/writing-a-proposal#elements-of-a-quality-proposal) for more tips. 
+Please, use the suggested [proposal template](gsoc-template.html) when applying. Check out [GSoC guides](https://google.github.io/gsocguides/student/writing-a-proposal#elements-of-a-quality-proposal) for more tips.
 
 Good places to start contributing to Xi are [easy](https://github.com/xi-editor/xi-editor/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy) and [help wanted](https://github.com/xi-editor/xi-editor/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues on GitHub.
 
@@ -75,7 +75,7 @@ Xi currently uses a plugin based on [syntect](https://github.com/trishume/syntec
 When this work is finished, the user should be able to place custom themes and syntax definitions in an appropriate place on the filesystem, and have those items automatically detected and loaded by syntect. Syntect should also generate new binary dumps including the new items, to avoid unduly impacting startup time.
 
 ### Difficulty
-This is low-hanging fruit for core development.  We already support syntax files. The work that would need to be done is to define RPC mechanism for a front-end to inform syntect of the syntax file path & for syntect to integrate a filesystem watcher to scan for changes. A minimal design docs or maybe even just an IRC discussion would be necessary. Additionally adding more syntax files built-in would improve the out-of-the box experience.  
+This is low-hanging fruit for core development.  We already support syntax files. The work that would need to be done is to define RPC mechanism for a front-end to inform syntect of the syntax file path & for syntect to integrate a filesystem watcher to scan for changes. A minimal design docs or maybe even just an Zulip discussion would be necessary. Additionally adding more syntax files built-in would improve the out-of-the box experience.
 
 There is opportunity for the student to expand the scope of the work to improve the performance of loading the theme files by compiling them into a binary format & caching them.  Would require some diligence to detect stale cache entries (updated theme file) or uninstalled themes.
 
@@ -97,15 +97,15 @@ The split-view work should be relatively easy core development work.  Diff/merge
 ## Workspace + Git
 
 ### Step 1 for an IDE experience
-A workspace plugin would enable project-based editing. This would provide a foundation for performing actions like building, running & debugging a target.  It would also provide various higher-scope tools (e.g. refactoring) with the knowledge necessary about how to perform those actions (what files are part of the compilation, where to look for documentation, etc).  
+A workspace plugin would enable project-based editing. This would provide a foundation for performing actions like building, running & debugging a target.  It would also provide various higher-scope tools (e.g. refactoring) with the knowledge necessary about how to perform those actions (what files are part of the compilation, where to look for documentation, etc).
 A git plugin would allow for operations like annotating lines with commit info and for viewing the diff of a particular commit. When the workspace plugin is loaded then there would also be status indications for untracked/modified status of project files.
 
 ### Outcome
-A workspace plugin that supports Cargo projects so that we could self-host.  Supporting CMake would be great too. This requires front-end integration as well for providing an “IDE” view. IDE’s typically have a single window that shows the project files + a view to edit a window. Additionally, at startup there’s an ability to provide a selection screen of which project(s) to open.  
+A workspace plugin that supports Cargo projects so that we could self-host.  Supporting CMake would be great too. This requires front-end integration as well for providing an “IDE” view. IDE’s typically have a single window that shows the project files + a view to edit a window. Additionally, at startup there’s an ability to provide a selection screen of which project(s) to open.
 Git integration at a minimum would entail a blame option & an ability to view the changes introduced within that diff (like Xcode).
 
 ### Difficulty
-This would be medium-difficulty core development work for the workspace. It would probably require having another entry-point in the front-end for an IDE view. It would reuse a lot of the core rendering code but the document management would probably be distinct. CMake & Cargo are two projects that would probably be fairly easy to integrate as the files that are part of Cargo are mostly deterministic from a static TOML file and CMake can export all its commands to a JSON file. It would require coming up with a thorough project structure model. For full completeness, consideration would have to be given to properly incorporate build.rs logic.  
+This would be medium-difficulty core development work for the workspace. It would probably require having another entry-point in the front-end for an IDE view. It would reuse a lot of the core rendering code but the document management would probably be distinct. CMake & Cargo are two projects that would probably be fairly easy to integrate as the files that are part of Cargo are mostly deterministic from a static TOML file and CMake can export all its commands to a JSON file. It would require coming up with a thorough project structure model. For full completeness, consideration would have to be given to properly incorporate build.rs logic.
 
 Most of the git blame work would simply require getting it to render correctly & efficiently. The git plugin itself shouldn’t be difficult since there exist great Rust bindings and git already supports blaming a line-range which is what the front-end would ask the plugin to provide.
 
@@ -134,7 +134,7 @@ The find functionality currently only supports plain-text search within the curr
  - Find + Find/replace within workspace files
  - Filter for matching lines. Show only matching lines with a configurable amount of context
  - Multiple queries. Match any number of queries and highlight them uniquely.
-All of these use-cases have received significant attention by the ripgrep project which has factored them out into standalone Rust libraries (as fast or significantly faster than other tools like venerable grep).  The workspace files integration would depend on the workspace plugin but significant development can be made even without it.  Filter & multiple queries would be features exclusive to xi not seen before in text editors (filter is available in command-line grep and multiple queries are kind of possible via regex search).  
+All of these use-cases have received significant attention by the ripgrep project which has factored them out into standalone Rust libraries (as fast or significantly faster than other tools like venerable grep).  The workspace files integration would depend on the workspace plugin but significant development can be made even without it.  Filter & multiple queries would be features exclusive to xi not seen before in text editors (filter is available in command-line grep and multiple queries are kind of possible via regex search).
 
 An additional feature for supporting multiple queries (each query highlighted separately but the search acting in a uniform way) would be super useful addition that would be unique to xi (often useful for log files).
 
@@ -150,7 +150,7 @@ There is a variety of levels of difficulty available, even within a work item.  
 ## Scriptable language bindings (C API)
 
 ### Provide an API for core data structures and actions, suitable for binding to scripting languages and GUI frontends
-Right now all communication between core and front-end, as well as between core and plug-ins, is mediated by a JSON-RPC communication mechanism. We’ve been finding that there are common operations (maintenance of the line case, for example) that would be worthwhile to make available for many clients; these are also typically performance sensitive, so would benefit from implementation in Rust. The project involves creating C API’s for such tasks, designed specifically to be easily wrapped in FFI bindings from scripting languages and the languages most commonly used to write front-ends.  
+Right now all communication between core and front-end, as well as between core and plug-ins, is mediated by a JSON-RPC communication mechanism. We’ve been finding that there are common operations (maintenance of the line case, for example) that would be worthwhile to make available for many clients; these are also typically performance sensitive, so would benefit from implementation in Rust. The project involves creating C API’s for such tasks, designed specifically to be easily wrapped in FFI bindings from scripting languages and the languages most commonly used to write front-ends.
 
 Related work would be similar FFI bindings for the xi-rope data structure, so plug-ins running as threads in the same process could have more direct access to the document contents.
 
@@ -165,7 +165,7 @@ This is probably medium difficulty and not particularly risky; it requires caref
 ## Flush out unit tests
 
 ### Provide ability to write a more robust set of tests
-We have some RPC tests but being able to express tests at a higher level (type  ‘A’, move cursor to X:Y, add cursor at A:B, transpose, paste “XYZ”, etc) would make it much easier to express the operations in a maintainable way & provide for ways to easily validate.  
+We have some RPC tests but being able to express tests at a higher level (type  ‘A’, move cursor to X:Y, add cursor at A:B, transpose, paste “XYZ”, etc) would make it much easier to express the operations in a maintainable way & provide for ways to easily validate.
 
 Follow-on work could include "property testing," which generates test cases automatically (resulting in higher coverage) and tests properties such as correctness of incremental algorithms.
 


### PR DESCRIPTION
## Summary
This PR just updates the various project docs to point to Zulip instead of IRC. 

## Related Issues
Resolves (for this repo): https://github.com/xi-editor/xi-editor/issues/961

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
