### PR TITLE
Use clearer notation in frontend-protocol.md

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -521,7 +521,7 @@ certainly represent at least initial and trailing sequences of invalid lines by
 their count; and the editing operations may be more efficiently done in-place
 than by copying from the old state to the new].
 
-The "copy" op appends the `n` lines `[old_ix: old_ix + n]` to the new lines
+The "copy" op appends the `n` lines `[old_ix .. old_ix + n]` to the new lines
 array, and increments `old_ix` by `n`.
 
 The "skip" op increments `old_ix` by `n`.


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary

In the fontend protocol description, was array range written `[i: j]`, which confused me. I think the rust notation `[i .. j]` is clearer.

