### PR TITLE
Add custom command support to rust plugin-lib

### DIFF
--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -113,6 +113,7 @@ pub enum HostNotification {
     Shutdown(EmptyStruct),
     TracingConfig { enabled: bool },
     LanguageChanged { view_id: ViewId, new_lang: LanguageId },
+    CustomCommand { view_id: ViewId, method: String, params: Value },
 }
 
 // ====================================================================

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -106,6 +106,11 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         self.plugin.language_changed(v, old_lang);
     }
 
+    fn do_custom_command(&mut self, view_id: ViewId, method: &str, params: Value) {
+        let v = bail!(self.views.get_mut(&view_id), method, self.pid, view_id);
+        self.plugin.custom_command(v, method, params);
+    }
+
     fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
         let plugin_id = self.pid.unwrap();
         buffers
@@ -202,6 +207,9 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
                 self.do_get_hover(view_id, request_id, position)
             }
             LanguageChanged { view_id, new_lang } => self.do_language_changed(view_id, new_lang),
+            CustomCommand { view_id, method, params } => {
+                self.do_custom_command(view_id, &method, params)
+            }
             Ping(..) => (),
         }
     }

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -39,6 +39,7 @@ mod view;
 use std::io;
 use std::path::Path;
 
+use serde_json::Value;
 use xi_core::plugin_rpc::{GetDataResponse, TextUnit};
 use xi_core::{ConfigTable, LanguageId};
 use xi_rope::interval::IntervalBounds;
@@ -175,6 +176,10 @@ pub trait Plugin {
     /// New language is available in the `view`, and old language is available in `old_lang`.
     #[allow(unused_variables)]
     fn language_changed(&mut self, view: &mut View<Self::Cache>, old_lang: LanguageId) {}
+
+    /// Called with a custom command.
+    #[allow(unused_variables)]
+    fn custom_command(&mut self, view: &mut View<Self::Cache>, method: &str, params: Value) {}
 
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that


### PR DESCRIPTION
Once upon a time, plugins could declare custom commands that they supported, which could be sent by the frontend. This was never supported by the new rust plugin-lib, although the functionality still exists. This adds support back to `plugin-lib`.