### PR TITLE
Fix advice in run_all_checks

### DIFF
--- a/rust/run_all_checks
+++ b/rust/run_all_checks
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 if !(cargo clippy --version); then
-    printf 'Checks requires clippy; try `rustup install clippy-preview`.\n'
+    printf 'Checks requires clippy; try `rustup component add clippy-preview`.\n'
+    printf "If that doesn't fix things; try `rustup self update`.\n"
     exit 1
 fi
 
 if !(cargo fmt --version); then
-    printf 'Checks requires rustfmt; try `rustup install rustfmt-preview`.\n'
+    printf 'Checks requires rustfmt; try `rustup component add rustfmt-preview`.\n'
+    printf "If that doesn't fix things; try `rustup self update`.\n"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
I was working on another PR and `run_all_checks` wasn't working because `clippy-preview` was not installed. I tried the advice but that didn't work. After some trial and error I figured out the right commands. I've updated the advice in `run_all_checks` for other newcomers. :) 

Example:
```sh
$ ./rust/run_all_checks
error: no such subcommand: `clippy`
Checks requires clippy; try `rustup install clippy-preview`.
```

## Related Issues
_None_

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
