### PR TITLE
Add is_identity for Delta

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -114,6 +114,17 @@ impl<N: NodeInfo> Delta<N> {
         }
     }
 
+    /// Returns `true` if applying the delta will cause no change.
+    pub fn is_identity(&self) -> bool {
+        if self.els.len() == 1 {
+            if let DeltaElement::Copy(beg, end) = self.els[0] {
+                return beg == 0 && end == self.base_len;
+            }
+        }
+
+        false
+    }
+
     /// Apply the delta to the given rope. May not work well if the length of the rope
     /// is not compatible with the construction of the delta.
     pub fn apply(&self, base: &Node<N>) -> Node<N> {
@@ -846,6 +857,15 @@ mod tests {
         };
 
         assert!(!delta.is_simple_delete());
+    }
+
+    #[test]
+    fn is_identity() {
+        let d = Delta::simple_edit(10..12, Rope::from("+"), TEST_STR.len());
+        assert_eq!(false, d.is_identity());
+
+        let d = Delta::simple_edit(0..0, Rope::from(""), TEST_STR.len());
+        assert_eq!(true, d.is_identity());
     }
 
     #[test]


### PR DESCRIPTION
Adds `is_identity` method for https://github.com/xi-editor/xi-editor/issues/987


## Related Issues
https://github.com/xi-editor/xi-editor/issues/987

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
