### PR TITLE
Syntect comment toggle

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1302,6 +1302,7 @@ version = "0.0.0"
 dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 3.0.2 (git+https://github.com/trishume/syntect.git)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "xi-core-lib 0.2.0",

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -84,6 +84,7 @@ pub(crate) enum SpecialEvent {
     Resize(Size),
     RequestLines(LineRange),
     RequestHover { request_id: usize, position: Option<Position> },
+    DebugToggleComment,
     ToggleRecording(Option<String>),
     PlayRecording(String),
     ClearRecording(String),
@@ -242,6 +243,7 @@ impl From<EditNotification> for EventDomain {
             Capitalize => BufferEvent::Capitalize.into(),
             Indent => BufferEvent::Indent.into(),
             Outdent => BufferEvent::Outdent.into(),
+            DebugToggleComment => SpecialEvent::DebugToggleComment.into(),
             HighlightFind { visible } => ViewEvent::HighlightFind { visible }.into(),
             SelectionForFind { case_sensitive } =>
                 ViewEvent::SelectionForFind { case_sensitive }.into(),

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -470,6 +470,7 @@ pub enum EditNotification {
     DebugWrapWidth,
     /// Prints the style spans present in the active selection.
     DebugPrintSpans,
+    DebugToggleComment,
     Uppercase,
     Lowercase,
     Capitalize,

--- a/rust/syntect-plugin/Cargo.toml
+++ b/rust/syntect-plugin/Cargo.toml
@@ -9,6 +9,7 @@ description = "A syntax highlighting plugin based on syntect."
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 toml = "0.4"


### PR DESCRIPTION
This is based off of #971; the meat here is just the last commit.

There are some things about this implementation that are... weird. It isn't totally clear that this should be in syntect and not in core.

closes #795

-------------

This adds syntax-aware comment toggling.

The implementation is sort of weird, in a way that maybe
highlights some of the general weirdness around this feature,
and also maybe illustrates some future directions for plugin-
provided commands.

Basically: comment toggling, like auto-indent, is syntax
dependant. Unlike auto-indent, however, it is also the result
of an explicit user action.

This is a funny case. It seems silly to add a 'toggle_comment'
command to the RPC protocol. We do need to route through core,
because we need to extract the lines to be commented; plugins
do not currently have access to selection state. However we only
expect this to be handled by one plugin.

So: this is a hack. This has given me some ideas about how
plugins can declare their capabilities, though; I'll open an
issue for that in a little bit.

In the meantime, this is a useful feature.