### PR TITLE
Core process exits with 1 on error

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process;
 
 use xi_core_lib::XiCore;
 use xi_rpc::RpcLoop;
@@ -227,6 +228,9 @@ fn main() {
 
     match rpc_looper.mainloop(|| stdin.lock(), &mut state) {
         Ok(_) => (),
-        Err(err) => error!("xi-core exited with error:\n{:?}", err),
+        Err(err) => {
+            error!("xi-core exited with error:\n{:?}", err);
+            process::exit(1);
+        }
     }
 }


### PR DESCRIPTION
Noticed this looking at something else; core should exit with a non-zero status on error.


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
