### PR TITLE
Fixing casting error from u32 to u64

### DIFF
--- a/rust/trace/src/sys_pid.rs
+++ b/rust/trace/src/sys_pid.rs
@@ -37,5 +37,5 @@ pub fn current_pid() -> u64 {
         fn GetCurrentProcessId() -> libc::c_ulong;
     }
 
-    unsafe { GetCurrentProcessId() as u64 }
+    unsafe { u64::from(GetCurrentProcessId()) as u64 }
 }

--- a/rust/trace/src/sys_pid.rs
+++ b/rust/trace/src/sys_pid.rs
@@ -37,5 +37,5 @@ pub fn current_pid() -> u64 {
         fn GetCurrentProcessId() -> libc::c_ulong;
     }
 
-    unsafe { u64::from(GetCurrentProcessId()) as u64 }
+    unsafe { u64::from(GetCurrentProcessId()) }
 }

--- a/rust/trace/src/sys_tid.rs
+++ b/rust/trace/src/sys_tid.rs
@@ -86,5 +86,5 @@ pub fn current_tid() -> Result<u64, libc::c_int> {
         fn GetCurrentThreadId() -> libc::c_ulong;
     }
 
-    unsafe { Ok(GetCurrentThreadId() as u64) }
+    unsafe { Ok(u64::from(GetCurrentProcessId())) as u64) }
 }

--- a/rust/trace/src/sys_tid.rs
+++ b/rust/trace/src/sys_tid.rs
@@ -86,5 +86,5 @@ pub fn current_tid() -> Result<u64, libc::c_int> {
         fn GetCurrentThreadId() -> libc::c_ulong;
     }
 
-    unsafe { Ok(u64::from(GetCurrentThreadId()))  }
+    unsafe { Ok(u64::from(GetCurrentThreadId())) }
 }

--- a/rust/trace/src/sys_tid.rs
+++ b/rust/trace/src/sys_tid.rs
@@ -86,5 +86,5 @@ pub fn current_tid() -> Result<u64, libc::c_int> {
         fn GetCurrentThreadId() -> libc::c_ulong;
     }
 
-    unsafe { Ok(u64::from(GetCurrentProcessId())) as u64) }
+    unsafe { Ok(u64::from(GetCurrentProcessId())) as u64 }
 }

--- a/rust/trace/src/sys_tid.rs
+++ b/rust/trace/src/sys_tid.rs
@@ -86,5 +86,5 @@ pub fn current_tid() -> Result<u64, libc::c_int> {
         fn GetCurrentThreadId() -> libc::c_ulong;
     }
 
-    unsafe { Ok(u64::from(GetCurrentProcessId())) as u64 }
+    unsafe { Ok(u64::from(GetCurrentThreadId()))  }
 }


### PR DESCRIPTION
## Summary
We were casting GetCurrentProcessId() as u64 which was giving error.

## Related Issues
     closes #992 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
