### PR TITLE
Update find status after cancel operation

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -288,6 +288,7 @@ impl View {
     pub(crate) fn unset_find(&mut self) {
         self.find.iter_mut().for_each(Find::unset);
         self.find.clear();
+        self.find_changed = FindStatusChange::All;
     }
 
     fn goto_line(&mut self, text: &Rope, line: u64) {


### PR DESCRIPTION
Find status needs to get updated after `unset_find` since it removes all search fields and frontends need to know about this. Also required for https://github.com/xi-editor/xi-mac/pull/361
