### PR TITLE
Remove cancel operation

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -135,13 +135,6 @@ Copies the active selection, returning their contents or `Null` if the selection
 
 Cut the active selection, returning their contents or `Null` if the selection was empty.
 
-#### cancel_operation
-
-`cancel_operation`
-
-Currently, this collapses selections and multiple cursors, and dehighlights
-searches.
-
 #### scroll
 
 `scroll [0,18]`
@@ -228,6 +221,7 @@ page_down_and_modify_selection
 yank
 transpose
 select_all
+collapse_selections
 add_selection_above
 add_selection_below
 ```

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -42,12 +42,12 @@ pub(crate) enum ViewEvent {
     FindNext { wrap_around: bool, allow_same: bool, modify_selection: SelectionModifier },
     FindPrevious { wrap_around: bool, allow_same: bool, modify_selection: SelectionModifier },
     FindAll,
-    Cancel,
     HighlightFind { visible: bool },
     SelectionForFind { case_sensitive: bool },
     Replace { chars: String, preserve_case: bool },
     SelectionForReplace,
     SelectionIntoLines,
+    CollapseSelections,
 }
 
 /// Events that modify the buffer
@@ -237,7 +237,6 @@ impl From<EditNotification> for EventDomain {
             DebugRewrap => SpecialEvent::DebugRewrap.into(),
             DebugWrapWidth => SpecialEvent::DebugWrapWidth.into(),
             DebugPrintSpans => SpecialEvent::DebugPrintSpans.into(),
-            CancelOperation => ViewEvent::Cancel.into(),
             Uppercase => BufferEvent::Uppercase.into(),
             Lowercase => BufferEvent::Lowercase.into(),
             Capitalize => BufferEvent::Capitalize.into(),
@@ -260,6 +259,7 @@ impl From<EditNotification> for EventDomain {
             ToggleRecording { recording_name } => SpecialEvent::ToggleRecording(recording_name).into(),
             PlayRecording { recording_name } => SpecialEvent::PlayRecording(recording_name).into(),
             ClearRecording { recording_name } => SpecialEvent::ClearRecording(recording_name).into(),
+            CollapseSelections => ViewEvent::CollapseSelections.into(),
         }
     }
 }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -720,7 +720,7 @@ mod tests {
         [|that] has three\n\
         [|lines]." );
 
-        ctx.do_edit(EditNotification::CancelOperation);
+        ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::MoveToRightEndOfLine);
         assert_eq!(harness.debug_render(),"\
         this is a string|\n\
@@ -739,7 +739,7 @@ mod tests {
         that has three\n\
         lines.|]" );
 
-        ctx.do_edit(EditNotification::CancelOperation);
+        ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::AddSelectionAbove);
         assert_eq!(harness.debug_render(),"\
         this is a string\n\
@@ -1673,7 +1673,7 @@ mod tests {
         ctx.do_edit(EditNotification::MoveToRightEndOfLine);
         ctx.do_edit(EditNotification::MoveWordLeftAndModifySelection);
         ctx.do_edit(EditNotification::Transpose);
-        ctx.do_edit(EditNotification::CancelOperation);
+        ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::MoveToRightEndOfLine);
         assert_eq!(harness.debug_render(),"\
         this is a about|\n\
@@ -1739,7 +1739,7 @@ mod tests {
         lines.\n\
         And lines with very different length.");
 
-        ctx.do_edit(EditNotification::CancelOperation);
+        ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::Gesture { line: 1, col: 5, ty: PointSelect });
         ctx.do_edit(EditNotification::AddSelectionBelow);
         assert_eq!(harness.debug_render(),"\
@@ -1749,7 +1749,7 @@ mod tests {
         lines|.\n\
         And lines with very different length.");
 
-        ctx.do_edit(EditNotification::CancelOperation);
+        ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::Gesture { line: 4, col: 10, ty: PointSelect });
         ctx.do_edit(EditNotification::AddSelectionAbove);
         assert_eq!(harness.debug_render(),"\

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -470,7 +470,6 @@ pub enum EditNotification {
     DebugWrapWidth,
     /// Prints the style spans present in the active selection.
     DebugPrintSpans,
-    CancelOperation,
     Uppercase,
     Lowercase,
     Capitalize,
@@ -509,6 +508,7 @@ pub enum EditNotification {
     ClearRecording {
         recording_name: String,
     },
+    CollapseSelections,
 }
 
 /// The edit related requests.

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -245,7 +245,7 @@ impl View {
             Drag(MouseAction { line, column, .. }) => {
                 self.do_drag(text, line, column, Affinity::default())
             }
-            Cancel => self.do_cancel(text),
+            CollapseSelections => self.collapse_selections(text),
             HighlightFind { visible } => {
                 self.highlight_find = visible;
                 self.find_changed = FindStatusChange::All;
@@ -274,21 +274,6 @@ impl View {
             GestureType::MultiLineSelect => self.select_line(text, offset, line, true),
             GestureType::MultiWordSelect => self.select_word(text, offset, true),
         }
-    }
-
-    fn do_cancel(&mut self, text: &Rope) {
-        // if we have active find highlights, we don't collapse selections
-        if self.find.is_empty() {
-            self.collapse_selections(text);
-        } else {
-            self.unset_find();
-        }
-    }
-
-    pub(crate) fn unset_find(&mut self) {
-        self.find.iter_mut().for_each(Find::unset);
-        self.find.clear();
-        self.find_changed = FindStatusChange::All;
     }
 
     fn goto_line(&mut self, text: &Rope, line: u64) {

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -254,7 +254,8 @@ const MOVEMENT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1",
 {"method":"edit","params":{"view_id":"view-id-1","method":"page_down_and_modify_selection","params":[]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"select_all","params":[]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_above","params":[]}}
-{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_below","params":[]}}"#;
+{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_below","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"collapse_selections","params":[]}}"#;
 
 const TEXT_EDIT_RPCS: &str =
     r#"{"method":"edit","params":{"view_id":"view-id-1","method":"insert","params":{"chars":"a"}}}


### PR DESCRIPTION
Removes `Cancel` and adds `CollapseSelections` → https://github.com/xi-editor/xi-editor/issues/1015

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
