### PR TITLE
Add at_or_next and at_or_prev to Cursor

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -321,12 +321,7 @@ fn compute_rewrap_width(
     let mut builder = BreakBuilder::new();
     let mut pos = start;
     let mut break_cursor = Cursor::new(&breaks, end);
-    // TODO: factor this into `at_or_next` method on cursor.
-    let mut next_break = if break_cursor.is_boundary::<BreaksBaseMetric>() {
-        Some(end)
-    } else {
-        break_cursor.next::<BreaksBaseMetric>()
-    };
+    let mut next_break = break_cursor.at_or_next::<BreaksBaseMetric>();
     loop {
         // iterate newly computed breaks and existing breaks until they converge
         if let Some(new_next) = ctx.wrap_one_line(pos) {
@@ -379,9 +374,7 @@ pub fn rewrap_width(
     // Find a point earlier than any possible breaks change. For simplicity, this is the
     // beginning of the paragraph, but going back two breaks would be better.
     let mut cursor = Cursor::new(&text, start);
-    if !cursor.is_boundary::<LinesMetric>() {
-        start = cursor.prev::<LinesMetric>().unwrap_or(0);
-    }
+    start = cursor.at_or_prev::<LinesMetric>().unwrap_or(0);
 
     let new_breaks = compute_rewrap_width(
         text,

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -670,6 +670,26 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         }
     }
 
+    /// Returns the current position if it is a boundary in this [`Metric`],
+    /// else behaves like [`next`](#method.next).
+    pub fn at_or_next<M: Metric<N>>(&mut self) -> Option<usize> {
+        if self.is_boundary::<M>() {
+            Some(self.pos())
+        } else {
+            self.next::<M>()
+        }
+    }
+
+    /// Returns the current position if it is a boundary in this [`Metric`],
+    /// else behaves like [`prev`](#method.prev).
+    pub fn at_or_prev<M: Metric<N>>(&mut self) -> Option<usize> {
+        if self.is_boundary::<M>() {
+            Some(self.pos())
+        } else {
+            self.prev::<M>()
+        }
+    }
+
     /// Returns an iterator with this cursor over the given [`Metric`].
     ///
     /// # Examples:
@@ -948,4 +968,19 @@ mod test {
         }
     }
 
+    #[test]
+    fn at_or_next() {
+        let text: Rope = "this\nis\nalil\nstring".into();
+        let mut cursor = Cursor::new(&text, 0);
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(0));
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(0));
+        cursor.set(1);
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(5));
+        assert_eq!(cursor.at_or_prev::<LinesMetric>(), Some(5));
+        cursor.set(6);
+        assert_eq!(cursor.at_or_prev::<LinesMetric>(), Some(5));
+        cursor.set(6);
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(8));
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(8));
+    }
 }


### PR DESCRIPTION
Another little fixup that can stand alone.


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
