### PR TITLE
Unify width and column wrapping

### DIFF
--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -25,17 +25,10 @@ use plugins::Command;
 use styles::ThemeSettings;
 use syntax::LanguageId;
 use tabs::ViewId;
+use width_cache::{WidthReq, WidthResponse};
 
 /// An interface to the frontend.
 pub struct Client(RpcPeer);
-
-#[derive(Serialize, Deserialize)]
-/// A request for measuring the widths of strings all of the same style
-/// (a request from core to front-end).
-pub struct WidthReq {
-    pub id: usize,
-    pub strings: Vec<String>,
-}
 
 impl Client {
     pub fn new(peer: RpcPeer) -> Self {
@@ -173,7 +166,7 @@ impl Client {
     }
 
     /// Ask front-end to measure widths of strings.
-    pub fn measure_width(&self, reqs: &[WidthReq]) -> Result<Vec<Vec<f64>>, xi_rpc::Error> {
+    pub fn measure_width(&self, reqs: &[WidthReq]) -> Result<WidthResponse, xi_rpc::Error> {
         let req_json = serde_json::to_value(reqs).expect("failed to serialize width req");
         let resp = self.0.send_rpc_request("measure_width", &req_json)?;
         Ok(serde_json::from_value(resp).expect("failed to deserialize width response"))

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -21,7 +21,7 @@ use xi_trace::trace_block;
 use xi_unicode::LineBreakLeafIter;
 
 use styles::{Style, N_RESERVED_STYLES};
-use width_cache::{Measure, Token, WidthCache};
+use width_cache::{Token, WidthCache, WidthMeasure};
 
 struct LineBreakCursor<'a> {
     inner: Cursor<'a, RopeInfo>,
@@ -92,7 +92,7 @@ struct RewrapCtx<'a, T: 'a> {
 // RPC overhead becomes significant. More than that, interactivity suffers.
 const MAX_POT_BREAKS: usize = 10_000;
 
-impl<'a, T: Measure> RewrapCtx<'a, T> {
+impl<'a, T: WidthMeasure> RewrapCtx<'a, T> {
     fn new(
         text: &'a Rope,
         /* _style_spans: &Spans<Style>, */ client: &'a T,
@@ -166,7 +166,7 @@ impl<'a, T: Measure> RewrapCtx<'a, T> {
 }
 
 /// Wrap the text (in batch mode) using width measurement.
-pub fn rewrap_all<T: Measure>(
+pub fn rewrap_all<T: WidthMeasure>(
     text: &Rope,
     width_cache: &mut WidthCache,
     _style_spans: &Spans<Style>,
@@ -188,7 +188,7 @@ pub fn rewrap_all<T: Measure>(
 //NOTE: incremental version of rewrap_all
 /// Compute a new chunk of breaks after an edit. Returns new breaks to replace
 /// the old ones. The interval [start..end] represents a frontier.
-fn compute_rewrap<T: Measure>(
+fn compute_rewrap<T: WidthMeasure>(
     text: &Rope,
     width_cache: &mut WidthCache,
     /* style_spans: &Spans<Style>, */ client: &T,
@@ -239,7 +239,7 @@ fn compute_rewrap<T: Measure>(
     builder.build()
 }
 
-pub fn rewrap<T: Measure>(
+pub fn rewrap<T: WidthMeasure>(
     breaks: &mut Breaks,
     text: &Rope,
     width_cache: &mut WidthCache, // _style_spans: &Spans<Style>,


### PR DESCRIPTION
This reimplements column-based wrapping using the existing width-based
system, which reduces the number of code paths for both creating and updating
breaks by up to 50%!

This is currently _slightly_ hacky; we have to clear the width cache when
switching between word and column wrapping, because column wrapping now
uses the width cache but stores codepoint counts instead of actual
measured widths.

This is temporary; assuming we keep column-based wrapping around at all,
it will make sense in the future to get the 'unit width' for a given
style from the frontend, and use that + UAX#11 to calculate actual widths.

--------

this is an initial step towards #610; I'd like to avoid maintaining two distinct code paths/algorithms when implementing incremental wrapping.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
