### PR TITLE
Add benchmarks for line_of_offset, offset_of_line

### DIFF
--- a/rust/core-lib/benches/wrap.rs
+++ b/rust/core-lib/benches/wrap.rs
@@ -1,0 +1,86 @@
+// Copyright 2018 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+
+extern crate test;
+extern crate xi_core_lib as xi_core;
+extern crate xi_rope;
+
+use test::Bencher;
+use xi_core::tabs::BufferId;
+use xi_core::view::View;
+use xi_rope::Rope;
+
+fn build_short_lines(n: usize) -> String {
+    let line =
+        "See it, the beautiful ball Poised in the toyshop window, Rounder than sun or moon.\n";
+    let mut s = String::new();
+    for _ in 0..n {
+        s += line;
+    }
+    s
+}
+
+#[bench]
+fn line_of_offset_no_breaks(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000));
+    let view = View::new(1.into(), BufferId::new(2));
+
+    let total_bytes = text.len();
+    b.iter(|| {
+        for i in 0..total_bytes {
+            let _line = view.line_of_offset(&text, i);
+        }
+    })
+}
+
+#[bench]
+fn line_of_offset_col_breaks(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000));
+    let mut view = View::new(1.into(), BufferId::new(2));
+    view.debug_force_rewrap_cols(&text, 20);
+
+    let total_bytes = text.len();
+    b.iter(|| {
+        for i in 0..total_bytes {
+            let _line = view.line_of_offset(&text, i);
+        }
+    })
+}
+
+#[bench]
+fn offset_of_line_no_breaks(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000));
+    let view = View::new(1.into(), BufferId::new(2));
+
+    b.iter(|| {
+        for i in 0..1_000 {
+            let _line = view.offset_of_line(&text, i);
+        }
+    })
+}
+
+#[bench]
+fn offset_of_line_col_breaks(b: &mut Bencher) {
+    let text = Rope::from(build_short_lines(1_000));
+    let mut view = View::new(1.into(), BufferId::new(2));
+    view.debug_force_rewrap_cols(&text, 20);
+
+    b.iter(|| {
+        for i in 0..1000 {
+            let _line = view.offset_of_line(&text, i);
+        }
+    })
+}

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -1183,6 +1183,20 @@ impl View {
     }
 }
 
+impl View {
+    /// Exposed for benchmarking
+    #[doc(hidden)]
+    pub fn debug_force_rewrap_cols(&mut self, text: &Rope, cols: usize) {
+        use xi_rpc::test_utils::DummyPeer;
+
+        let spans: Spans<Style> = Spans::default();
+        let mut width_cache = WidthCache::new();
+        let client = Client::new(Box::new(DummyPeer));
+        self.update_wrap_state(cols, false);
+        self.rewrap(text, &mut width_cache, &client, &spans);
+    }
+}
+
 // utility function to clamp a value within the given range
 fn clamp(x: usize, min: usize, max: usize) -> usize {
     if x < min {


### PR DESCRIPTION
The implementations of these are going to get a bit trickier when we
separate hard and soft breaks, so it will be good to have benchmarks in
place.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
