### PR TITLE
Move indentation logic into PluginState and consider decrease

### DIFF
--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -47,7 +47,7 @@ const INDENTATION_PRIORITY: u64 = 100;
 type EditBuilder = DeltaBuilder<RopeInfo>;
 
 /// Edit types that will get processed.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum EditType {
     Insert,
     Newline,
@@ -217,7 +217,7 @@ impl<'a> PluginState {
     }
 
     pub fn indent_lines(&mut self, view: &mut MyView, syntax_set: &SyntaxSet) {
-        for (line_of_edit, edit_type) in self.indentation_state.to_vec().into_iter() {
+        for (line_of_edit, edit_type) in self.indentation_state.to_vec() {
             match edit_type {
                 EditType::Newline => self
                     .autoindent_line(view, syntax_set, line_of_edit)

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -481,8 +481,7 @@ impl<'a> PluginState {
                     .ok()
                     .and_then(|line| line.as_bytes().iter().position(|b| *b != b' ' && *b != b'\t'))
                     .unwrap_or(0)
-            })
-            .min()
+            }).min()
             .unwrap_or(0);
 
         let comment_txt = Rope::from(&comment_str);


### PR DESCRIPTION
This PR moves the indentation logic into `PluginState`.
Now it also checks if a line should be decreased after a newline.

## Related Issues

https://github.com/xi-editor/xi-editor/issues/1003


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
