### PR TITLE
🏗 Adding is_empty function to Rope::Node<N>

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -111,7 +111,7 @@ impl Lines {
     pub(crate) fn set_wrap_width(&mut self, text: &Rope, wrap: WrapWidth) {
         self.work.clear();
         self.add_task(0..text.len());
-        if self.breaks.len() == 0 || self.wrap.differs_in_kind(wrap) {
+        if self.breaks.is_empty() || self.wrap.differs_in_kind(wrap) {
             // we keep breaks while resizing, for more efficient invalidation
             self.breaks = Breaks::new_no_break(text.len());
         }

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -574,7 +574,7 @@ impl CoreState {
             .get(&buffer_id)
             .expect("existing buffer_id must have corresponding editor");
 
-        if editor.borrow().get_buffer().len() == 0 {
+        if editor.borrow().get_buffer().is_empty() {
             return None;
         }
 

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -53,10 +53,10 @@ pub struct InsertDelta<N: NodeInfo>(Delta<N>);
 impl<N: NodeInfo> Delta<N> {
     pub fn simple_edit<T: IntervalBounds>(interval: T, rope: Node<N>, base_len: usize) -> Delta<N> {
         let mut builder = Builder::new(base_len);
-        if rope.len() > 0 {
-            builder.replace(interval, rope);
-        } else {
+        if rope.is_empty() {
             builder.delete(interval);
+        } else {
+            builder.replace(interval, rope);
         }
         builder.build()
     }
@@ -592,7 +592,7 @@ impl<N: NodeInfo> Builder<N> {
     /// is not properly sorted.
     pub fn replace<T: IntervalBounds>(&mut self, interval: T, rope: Node<N>) {
         self.delete(interval);
-        if rope.len() > 0 {
+        if !rope.is_empty() {
             self.delta.els.push(DeltaElement::Insert(rope));
         }
     }

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -187,7 +187,7 @@ impl Engine {
     /// ancestor in order to be mergeable.
     pub fn new(initial_contents: Rope) -> Engine {
         let mut engine = Engine::empty();
-        if initial_contents.len() > 0 {
+        if !initial_contents.is_empty() {
             let first_rev = engine.get_head_rev_id().token();
             let delta = Delta::simple_edit(Interval::new(0, 0), initial_contents, 0);
             engine.edit_rev(0, 0, first_rev, delta);

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -208,6 +208,10 @@ impl<N: NodeInfo> Node<N> {
         self.0.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     fn height(&self) -> usize {
         self.0.height
     }
@@ -972,6 +976,12 @@ mod test {
             prev_offset = offset;
         }
         assert_eq!(cursor.next::<LinesMetric>(), None);
+    }
+
+    #[test]
+    fn node_is_empty() {
+        let text = Rope::from(String::new());
+        assert_eq!(text.is_empty(), true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds an `is_empty` function to `Rope::Node<N>`

## Related Issues
closes  #1024

## Checklist

- [x] Implement is_empty function
- [x] Add unit tests
- [x] Consider refactoring existing code to use `is_empty`.

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
