### PR TITLE
Incremental word wrap initial impl

### DIFF
--- a/rust/core-lib/src/line_cache_shadow.rs
+++ b/rust/core-lib/src/line_cache_shadow.rs
@@ -149,29 +149,6 @@ impl LineCacheShadow {
         *self = b.build();
     }
 
-    /// Invalidates all lines after (and including) `at_line`.
-    pub fn truncate(&mut self, at_line: usize) {
-        let mut b = Builder::new();
-        let mut line_num = 0;
-        let mut inval_after = 0;
-        for span in &self.spans {
-            if line_num + span.n < at_line {
-                b.add_span(span.n, span.start_line_num, span.validity);
-            } else if line_num < at_line {
-                let n_good = at_line - line_num;
-                debug_assert!(n_good < span.n);
-                b.add_span(at_line - line_num, span.start_line_num, span.validity);
-                inval_after += span.n - n_good;
-            } else {
-                inval_after += span.n;
-            }
-            line_num += span.n;
-        }
-        b.add_span(inval_after, 0, INVALID);
-        b.set_dirty(true);
-        *self = b.build();
-    }
-
     pub fn partial_invalidate(&mut self, start: usize, end: usize, invalid: Validity) {
         let mut clean = true;
         let mut line_num = 0;

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -246,13 +246,17 @@ impl Lines {
         // find our minimum convergence point.
         // this is the next break if hard or the second next if soft, or EOF.
         let mut cursor = MergedBreaks::new(text, &self.breaks);
+
+        cursor.set_offset(iv.start);
+        let prev_break = cursor.offset;
+
         cursor.set_offset(iv.start + newlen);
         cursor.next();
         let next_valid_break =
             if cursor.is_hard() { cursor.offset } else { cursor.next().unwrap_or(text.len()) };
 
         //FIXME: update existing work items as necessary
-        let new_task = iv.start..next_valid_break;
+        let new_task = prev_break..next_valid_break;
         self.add_task(new_task);
 
         // possible if the whole buffer is deleted, e.g

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -78,6 +78,7 @@ pub type BufferIdentifier = BufferId;
 
 /// Totally arbitrary; we reserve this space for `ViewId`s
 pub(crate) const RENDER_VIEW_IDLE_MASK: usize = 1 << 25;
+pub(crate) const REWRAP_VIEW_IDLE_MASK: usize = 1 << 26;
 
 const NEW_VIEW_IDLE_TOKEN: usize = 1001;
 
@@ -545,6 +546,9 @@ impl CoreState {
             other if (other & RENDER_VIEW_IDLE_MASK) != 0 => {
                 self.handle_render_timer(other ^ RENDER_VIEW_IDLE_MASK)
             }
+            other if (other & REWRAP_VIEW_IDLE_MASK) != 0 => {
+                self.handle_rewrap_callback(other ^ REWRAP_VIEW_IDLE_MASK)
+            }
             other => panic!("unexpected idle token {}", other),
         };
     }
@@ -635,6 +639,14 @@ impl CoreState {
         let id: ViewId = token.into();
         if let Some(mut ctx) = self.make_context(id) {
             ctx._finish_delayed_render();
+        }
+    }
+
+    /// Callback for doing word wrap on a view
+    fn handle_rewrap_callback(&mut self, token: usize) {
+        let id: ViewId = token.into();
+        if let Some(mut ctx) = self.make_context(id) {
+            ctx.do_rewrap_batch();
         }
     }
 

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -893,7 +893,6 @@ impl View {
         let visible = self.first_line..self.first_line + self.height;
         let inval = self.lines.rewrap_chunk(text, width_cache, client, spans, visible);
         if let Some(InvalLines { start_line, inval_count, new_count }) = inval {
-            debug!("replaced {} breaks with {} at {}", inval_count, new_count, start_line);
             self.lc_shadow.edit(start_line, start_line + inval_count, new_count);
         }
     }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -912,10 +912,10 @@ impl View {
     ) {
         let visible = self.first_line..self.first_line + self.height;
         match self.lines.after_edit(text, last_text, delta, width_cache, client, visible) {
-            Ok(InvalLines { start_line, inval_count, new_count }) => {
+            Some(InvalLines { start_line, inval_count, new_count }) => {
                 self.lc_shadow.edit(start_line, start_line + inval_count, new_count);
             }
-            Err(first_wrapped_line) => self.lc_shadow.truncate(first_wrapped_line),
+            None => self.set_dirty(text),
         }
 
         // Any edit cancels a drag. This is good behavior for edits initiated through

--- a/rust/core-lib/src/width_cache.rs
+++ b/rust/core-lib/src/width_cache.rs
@@ -149,7 +149,7 @@ impl<'a> WidthBatchReq<'a> {
 
     /// Resolves pending measurements to concrete widths using the provided [`WidthMeasure`].
     /// On success, the tokens given by `request` will resolve in the cache.
-    pub fn resolve_pending<T: ?Sized + WidthMeasure>(
+    pub fn resolve_pending<T: WidthMeasure + ?Sized>(
         &mut self,
         handler: &T,
     ) -> Result<(), xi_rpc::Error> {

--- a/rust/core-lib/src/width_cache.rs
+++ b/rust/core-lib/src/width_cache.rs
@@ -149,7 +149,10 @@ impl<'a> WidthBatchReq<'a> {
 
     /// Resolves pending measurements to concrete widths using the provided [`WidthMeasure`].
     /// On success, the tokens given by `request` will resolve in the cache.
-    pub fn resolve_pending<T: WidthMeasure>(&mut self, handler: &T) -> Result<(), xi_rpc::Error> {
+    pub fn resolve_pending<T: ?Sized + WidthMeasure>(
+        &mut self,
+        handler: &T,
+    ) -> Result<(), xi_rpc::Error> {
         // The 0.0 values should all get replaced with actual widths, assuming the
         // shape of the response from the front-end matches that of the request.
         if self.pending_tok > self.cache.widths.len() {


### PR DESCRIPTION
Edit: this includes commits from #1033, but maybe that should just get closed.

This is less ambitious than I'd initially planned; I really ended up getting stuck getting the partial invalidation correct, so this leaves the current behaviour in place where we invalidate everything on edit when wrap is turned on. I hope to revisit that soon, but this seemed like a good checkpoint.

There is clear follow-up here: I'd like to still do longest line tracking and logical vs visual lines.

There's also a major grossness where wrapping in a big document will cause the viewport to move after wrapping appears to be finished, because we're wrapping above the viewport and it changes offsets. But this is tractable.

In any case I think this is a good foundation, and likely worth merging as-is, but I expect to test it more over the next couple of days.

closes #610 
progress on #937 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
