### PR TITLE
Don't render on plugin_stopped unless necessary

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -468,11 +468,17 @@ impl<'a> EventContext<'a> {
 
     pub(crate) fn plugin_stopped(&mut self, plugin: &Plugin) {
         self.client.plugin_stopped(self.view_id, &plugin.name, 0);
-        self.with_editor(|ed, view, _, _| {
-            ed.get_layers_mut().remove_layer(plugin.id);
-            view.set_dirty(ed.get_buffer());
+        let needs_render = self.with_editor(|ed, view, _, _| {
+            if ed.get_layers_mut().remove_layer(plugin.id).is_some() {
+                view.set_dirty(ed.get_buffer());
+                true
+            } else {
+                false
+            }
         });
-        self.render();
+        if needs_render {
+            self.render();
+        }
     }
 
     pub(crate) fn do_plugin_update(&mut self, update: Result<Value, RpcError>) {


### PR DESCRIPTION
This fixes a potential crash where a plugin exiting immediately after launch
could trigger a render before view setup finished.

closes #1045

----

This wasn't the fix I'd initially envisioned but I think this makes more sense. I believe this crash can only be caused by early plugin exit, and on early plugin exit the plugin will not have had the chance to add any spans (or do anything else) so this will prevent the render, which is the cause of the crash. This will also reduce unnecessary invalidation of the line cache in the general case of a plugin that didn't add style spans exiting, which is itself an (infinitesimal) efficiency improvement.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
