### PR TITLE
Fix panic when transposing with no text or at EOF

### DIFF
--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -638,7 +638,8 @@ impl Editor {
                 if start >= last {
                     let end_line_offset =
                         view.offset_of_line(&self.text, view.line_of_offset(&self.text, end));
-                    if end == middle || end == end_line_offset {
+                    // include end != self.text.len() because if the editor is entirely empty, we dont' want to pull from empty space
+                    if (end == middle || end == end_line_offset) && end != self.text.len() {
                         middle = start;
                         start = self.text.prev_grapheme_offset(middle).unwrap_or(0);
                         end = middle.wrapping_add(1);

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -1022,29 +1022,4 @@ mod tests {
         assert_eq!(editor.get_buffer().to_string(), "sshello");
     }
 
-    #[test]
-    fn empty_transpose() {
-        let mut editor = Editor::with_text("");
-        let view = View::new(1.into(), BufferId::new(2));
-
-        editor.do_transpose(&view);
-
-        assert_eq!(editor.text.len(), 0);
-    }
-
-    // This is the issue reported by #962
-    #[test]
-    fn eol_multicursor_transpose() {
-        let mut editor = Editor::with_text("word\n");
-        let mut view = View::new(1.into(), BufferId::new(2));
-
-        let mut selection = Selection::new();
-        selection.add_region(SelRegion::caret(4)); // end of the first line
-        selection.add_region(SelRegion::caret(5)); // at eof
-        view.set_selection(&editor.text, selection);
-
-        editor.do_transpose(&view);
-
-        assert_eq!(editor.get_buffer().to_string(), "wor\nd");
-    }
 }

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -997,7 +997,7 @@ fn count_lines(s: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BufferId;
+
     #[test]
     fn plugin_edit() {
         let base_text = "hello";

--- a/rust/core-lib/src/editor.rs
+++ b/rust/core-lib/src/editor.rs
@@ -997,6 +997,7 @@ fn count_lines(s: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BufferId;
     #[test]
     fn plugin_edit() {
         let base_text = "hello";
@@ -1019,5 +1020,31 @@ mod tests {
         editor.apply_plugin_edit(edit_one);
 
         assert_eq!(editor.get_buffer().to_string(), "sshello");
+    }
+
+    #[test]
+    fn empty_transpose() {
+        let mut editor = Editor::with_text("");
+        let view = View::new(1.into(), BufferId::new(2));
+
+        editor.do_transpose(&view);
+
+        assert_eq!(editor.text.len(), 0);
+    }
+
+    // This is the issue reported by #962
+    #[test]
+    fn eol_multicursor_transpose() {
+        let mut editor = Editor::with_text("word\n");
+        let mut view = View::new(1.into(), BufferId::new(2));
+
+        let mut selection = Selection::new();
+        selection.add_region(SelRegion::caret(4)); // end of the first line
+        selection.add_region(SelRegion::caret(5)); // at eof
+        view.set_selection(&editor.text, selection);
+
+        editor.do_transpose(&view);
+
+        assert_eq!(editor.get_buffer().to_string(), "wor\nd");
     }
 }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -1844,4 +1844,30 @@ mod tests {
         // no change should be made
         assert_eq!(rev_token, new_rev_token);
     }
+
+    
+    #[test]
+    fn empty_transpose() {
+        let harness = ContextHarness::new("");
+        let mut ctx = harness.make_context();
+
+        ctx.do_edit(EditNotification::Transpose);
+
+        assert_eq!(harness.debug_render(), ""); // should be noop
+    }
+
+    // This is the issue reported by #962
+    #[test]
+    fn eol_multicursor_transpose() {
+        use crate::rpc::GestureType::*;
+
+        let harness = ContextHarness::new("word\n");
+        let mut ctx = harness.make_context();
+
+        ctx.do_edit(EditNotification::Gesture{line: 0, col: 4, ty: PointSelect}); // end of first line
+        ctx.do_edit(EditNotification::AddSelectionBelow); // add cursor below that, at eof
+        ctx.do_edit(EditNotification::Transpose);
+
+        assert_eq!(harness.debug_render(), "wor\nd|");
+    }
 }

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -1853,7 +1853,7 @@ mod tests {
 
         ctx.do_edit(EditNotification::Transpose);
 
-        assert_eq!(harness.debug_render(), ""); // should be noop
+        assert_eq!(harness.debug_render(), "|"); // should be noop
     }
 
     // This is the issue reported by #962


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
Fix a bug where xi-core would panic when transposing (Ctrl+T) on a empty file.

Steps to reproduce:

Open any XI editor (any should work, I personally tested on xi-gtk)
Press Ctrl+T
**panic**

Or the steps described in #962.

After this fix, it follows the expected behavior of not doing anything, and not panicking.

I have added a check to make sure the `end` index is not set to anything above the length of the text, which was causing the crash. 

Additionally, I have added two tests that previously panicked and now pass.

<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
* #962: This pull request also fixes this bug

<!---
GitHub has built-in functionality for closing issues when PR's are merged. TLDR: `closes #1` closes issue number 1 when the PR merges.
See [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) for more info.
--->
Closes #962

<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->
## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
