### PR TITLE
Send real line numbers with updates

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -498,6 +498,7 @@ interface Op {
   op: "copy" | "skip" | "invalidate" | "update" | "ins"
   n: number  // number of lines affected
   lines?: Line[]  // only present when op is "update" or "ins"
+  ln?: number // the logical number for this line; null if this line is a soft break
 }
 ```
 
@@ -516,7 +517,11 @@ their count; and the editing operations may be more efficiently done in-place
 than by copying from the old state to the new].
 
 The "copy" op appends the `n` lines `[old_ix .. old_ix + n]` to the new lines
-array, and increments `old_ix` by `n`.
+array, and increments `old_ix` by `n`. Additionally, "copy" includes the `ln`
+field; this represents the new logical line number (that is, the 'real' line
+number, ignoring word wrap) of the first line to be copied. **Note:** if the
+first line to be copied is itself a wrapped line, the `ln` number will need to
+be incremented in order to be correct for the first 'real' line.
 
 The "skip" op increments `old_ix` by `n`.
 
@@ -537,6 +542,7 @@ present in the old state is copied at most once to the new state).
 ```
 interface Line {
   text?: string  // present when op is "update"
+  ln?: number // the logical/'real' line number for this line.
   cursor?: number[]  // utf-8 code point offsets, in increasing order
   styles?: number[]  // length is a multiple of 3, see below
 }

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -554,8 +554,8 @@ impl View {
         style_spans: &Spans<Style>,
         line_num: usize,
     ) -> Value {
-        let start_pos = line.start;
-        let pos = line.end;
+        let start_pos = line.interval.start;
+        let pos = line.interval.end;
         let l_str = text.slice_to_cow(start_pos..pos);
         let mut cursors = Vec::new();
         let mut selections = Vec::new();
@@ -604,6 +604,9 @@ impl View {
 
         if !cursors.is_empty() {
             result["cursor"] = json!(cursors);
+        }
+        if let Some(line_num) = line.line_num {
+            result["ln"] = json!(line_num);
         }
         result
     }


### PR DESCRIPTION
With this PR, we will send (and update) logical line numbers when updating the client's line cache.

I wanted to get this finished before trying to fix the rewrap jitter, because this would've caused a related problem: even if the viewport didn't move during rewrap above the visible area, the line numbers would still have changed.

This _kind of_ depends on #1054; it works fine without it, but only because we're constantly invalidating the cache and so don't have to deal with stale updates.

closes #184 
progress on #937 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
