### PR TITLE
Reindent

### DIFF
--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -85,6 +85,7 @@ pub(crate) enum SpecialEvent {
     RequestLines(LineRange),
     RequestHover { request_id: usize, position: Option<Position> },
     DebugToggleComment,
+    Reindent,
     ToggleRecording(Option<String>),
     PlayRecording(String),
     ClearRecording(String),
@@ -243,6 +244,7 @@ impl From<EditNotification> for EventDomain {
             Capitalize => BufferEvent::Capitalize.into(),
             Indent => BufferEvent::Indent.into(),
             Outdent => BufferEvent::Outdent.into(),
+            Reindent => SpecialEvent::Reindent.into(),
             DebugToggleComment => SpecialEvent::DebugToggleComment.into(),
             HighlightFind { visible } => ViewEvent::HighlightFind { visible }.into(),
             SelectionForFind { case_sensitive } =>

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -473,6 +473,7 @@ pub enum EditNotification {
     Uppercase,
     Lowercase,
     Capitalize,
+    Reindent,
     Indent,
     Outdent,
     /// Indicates whether find highlights should be rendered

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -483,6 +483,17 @@ impl<'a> PluginState {
             .sum()
     }
 
+    fn reindent(
+        &mut self,
+        view: &mut MyView,
+        syntax_set: &SyntaxSet,
+        lines: &[(usize, usize)],
+    ) {
+        for (start, end) in lines {
+            self.bulk_autoindent(view, syntax_set, *start, *end);
+        }
+    }
+
     fn toggle_comment(
         &mut self,
         view: &mut MyView,
@@ -678,7 +689,12 @@ impl<'a> Plugin for Syntect<'a> {
                 let lines: Vec<(usize, usize)> = serde_json::from_value(params).unwrap();
                 let state = self.view_state.get_mut(&view.get_id()).unwrap();
                 state.toggle_comment(view, self.syntax_set, &lines);
-            }
+            },
+            "reindent" => {
+                let lines: Vec<(usize, usize)> = serde_json::from_value(params).unwrap();
+                let state = self.view_state.get_mut(&view.get_id()).unwrap();
+                state.reindent(view, self.syntax_set, &lines);
+            },
             other => eprintln!("syntect received unexpected command {}", other),
         }
     }


### PR DESCRIPTION
Adds an option to reindent selected text (https://github.com/xi-editor/xi-editor/issues/1002).

https://github.com/xi-editor/xi-mac/pull/385 adds xi-mac support

## Review Checklist

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
