### PR TITLE
Fix logic error in Cursor::next

### DIFF
--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -668,6 +668,9 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
             // At this point, we know that (1) the next boundary is not not in
             // the cached subtree, (2) self.position corresponds to the begining
             // of the first leaf after the cached subtree.
+            if self.position == self.root.len() {
+                return Some(self.position);
+            }
             self.descend();
             return self.next::<M>();
         } else {
@@ -987,5 +990,15 @@ mod test {
         cursor.set(6);
         assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(8));
         assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(8));
+    }
+
+    #[test]
+    fn next_zero_measure_large() {
+        let mut text = Rope::from("a");
+        for _ in 0..24 {
+            text = Node::concat(text.clone(), text);
+            let mut cursor = Cursor::new(&text, 0);
+            assert_eq!(cursor.next::<LinesMetric>(), Some(text.len()));
+        }
     }
 }


### PR DESCRIPTION
It was missing the end of the rope in cases where the tree was large.

Fixes #1062

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.

(I'll do some doc updates as a separate PR)