### PR TITLE
Ensure line breaks are up to date after movement

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -137,6 +137,9 @@ impl<'a> EventContext<'a> {
             E::View(cmd) => {
                 self.with_view(|view, text| view.do_edit(text, cmd));
                 self.editor.borrow_mut().update_edit_type();
+                if self.with_view(|v, t| v.needs_wrap_in_visible_region(t)) {
+                    self.rewrap();
+                }
             }
             E::Buffer(cmd) => {
                 self.with_editor(|ed, view, k_ring, conf| ed.do_edit(view, k_ring, conf, cmd))
@@ -260,14 +263,14 @@ impl<'a> EventContext<'a> {
     fn after_edit(&mut self, author: &str) {
         let _t = trace_block("EventContext::after_edit", &["core"]);
 
-        let mut ed = self.editor.borrow_mut();
-        let (delta, last_text, drift) = match ed.commit_delta() {
+        let edit_info = self.editor.borrow_mut().commit_delta();
+        let (delta, last_text, drift) = match edit_info {
             Some(edit_info) => edit_info,
             None => return,
         };
 
-        self.update_views(&ed, &delta, &last_text, drift);
-        self.update_plugins(&mut ed, delta, author);
+        self.update_views(&self.editor.borrow(), &delta, &last_text, drift);
+        self.update_plugins(&mut self.editor.borrow_mut(), delta, author);
 
         //if we have no plugins we always render immediately.
         if !self.plugins.is_empty() {
@@ -508,9 +511,9 @@ impl<'a> EventContext<'a> {
         }
     }
 
-    /// Tells the view to rewrap a batch of lines. This guarantees that the currently visible region
-    /// will be correctly wrapped; the caller should check if additional wrapping is necessary and
-    /// schedule that if so.
+    /// Tells the view to rewrap a batch of lines, if needed. This guarantees that
+    /// the currently visible region will be correctly wrapped; the caller should
+    /// check if additional wrapping is necessary and schedule that if so.
     fn rewrap(&mut self) {
         let mut view = self.view.borrow_mut();
         let ed = self.editor.borrow();

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -155,6 +155,11 @@ impl Lines {
         self.wrap == WrapWidth::None || self.work.is_empty()
     }
 
+    /// Returns `true` if this interval is part of an incomplete task.
+    pub(crate) fn interval_needs_wrap(&self, iv: Interval) -> bool {
+        self.work.iter().any(|t| !t.intersect(iv).is_empty())
+    }
+
     pub(crate) fn visual_line_of_offset(&self, text: &Rope, offset: usize) -> usize {
         let mut line = text.line_of_offset(offset);
         if self.wrap != WrapWidth::None {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -201,6 +201,15 @@ impl View {
         !self.lines.is_converged()
     }
 
+    pub(crate) fn needs_wrap_in_visible_region(&self, text: &Rope) -> bool {
+        if self.lines.is_converged() {
+            false
+        } else {
+            let visible_region = self.interval_of_visible_region(text);
+            self.lines.interval_needs_wrap(visible_region)
+        }
+    }
+
     pub(crate) fn do_edit(&mut self, text: &Rope, cmd: ViewEvent) {
         use self::ViewEvent::*;
         match cmd {
@@ -858,6 +867,13 @@ impl View {
             }
         }
         offset
+    }
+
+    /// Returns the byte range of the currently visible lines.
+    fn interval_of_visible_region(&self, text: &Rope) -> Interval {
+        let start = self.offset_of_line(text, self.first_line);
+        let end = self.offset_of_line(text, self.first_line + self.height + 1);
+        Interval::new(start, end)
     }
 
     // use own breaks if present, or text if not (no line wrapping)


### PR DESCRIPTION
With this PR, we will verify that the visible region has up to date line breaks, creating them if necessary, before rendering the view.

Progress on  #1053

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.