### PR TITLE
Keep viewport anchored during incremental rewrap

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -493,6 +493,7 @@ update
   ops: Op[]
   view-id: string
   pristine: bool
+  shift?: number
 
 interface Op {
   op: "copy" | "skip" | "invalidate" | "update" | "ins"
@@ -507,6 +508,12 @@ has unsaved changes.
 
 The `rev` field is not present in current builds, but will be at some point in
 the future.
+
+The `shift` field is only present when the update is the result of the
+rewrapping the view; the value is a signed integer, which represents the number
+of lines added or removed above the visible region; assuming the frontend is
+keeping track of its first line, it should adjust that number by the value in
+this field, in order to avoid jumping around during (or after) rewrapping.
 
 An update request can be seen as a function from the old client cache state to a
 new one. During evaluation, maintain an index (`old_ix`) into the old `lines`

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -241,6 +241,8 @@ impl Client {
 pub struct Update {
     pub(crate) ops: Vec<UpdateOp>,
     pub(crate) pristine: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) shift: Option<isize>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
This introduces the concept of anchors and drift. Well, shift. I was
calling it drift in my head but it's shift in the code, which is less
poetic but more clearly suggests intentionality.

To state the problem: when we're calculating new line breaks, we do it
incrementally; that is, we calculate the breaks for the visible region,
render that immediately, and then incrementally calculate the breaks for
the rest of the document. The problem here comes when the incremental
work is happening above the visible region; this can change the number
of visual lines in the document, which means that the line the client
thinks is line 50 is now line 68; this means the view will jump
unexpectedly as these updates come in.

The solution is to pick an anchor point during rewrapping; in this
commit the anchor point is the offset of the newline character preceding
the first visible line.

We wrap the lines between this anchor point and the end of the view
immediately; all subsequent batches of wrapping happen either above or
below this point. If it happens above, we keep a running tally of the
number of lines added or removed; during the next update, we take this
number (a signed integer) and send it to the frontend as the "shift"
field of the "update" RPC. the frontend then reorients itself by
translating what it thinks its current position is by the "shift" value.
This way the view stays fixed, even as relative line numbers change.

-------

cc @eyelash 
progress on #1053 

This is meant to be used with #1065; it will be a bit jankier without that patch.

There will probably be some fiddling with this around when and where we set the anchor, and how we calculate batch size, but this is the last major bit of the incremental wrap work.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.