### PR TITLE
Rework cursor boundaries

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -682,8 +682,14 @@ impl<'a> MergedBreaks<'a> {
     fn set_offset(&mut self, offset: usize) {
         self.text.set(offset);
         self.soft.set(offset);
-        self.text.at_or_prev::<LinesMetric>();
-        self.soft.at_or_prev::<BreaksMetric>();
+        if offset > 0 {
+            if self.text.at_or_prev::<LinesMetric>().is_none() {
+                self.text.set(0);
+            }
+            if self.soft.at_or_prev::<BreaksMetric>().is_none() {
+                self.soft.set(0);
+            }
+        }
 
         // self.offset should be at the first valid break immediately preceding `offset`, or 0.
         // the position of the non-break cursor should be > than that of the break cursor, or EOF.
@@ -1054,9 +1060,7 @@ mod tests {
 
         cursor.set(0);
         let breaks = cursor.iter::<BreaksMetric>().collect::<Vec<_>>();
-        // soft breaks includes a break at EOF, which we don't expect,
-        // because the end of the node is a boundary in all metrics?
-        assert_eq!(breaks, vec![2, 4, 6, 8]);
+        assert_eq!(breaks, vec![2, 4, 6]);
     }
 
     #[test]

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -1064,6 +1064,15 @@ mod tests {
     }
 
     #[test]
+    fn expected_soft_with_hard() {
+        let text: Rope = "aa\nbb cc\ncc dd ee ff\ngggg".into();
+        let Lines { breaks, .. } = make_lines(&text, 2.);
+        let mut cursor = Cursor::new(&breaks, 0);
+        let breaks = cursor.iter::<BreaksMetric>().collect::<Vec<_>>();
+        assert_eq!(breaks, vec![6, 12, 15, 18]);
+    }
+
+    #[test]
     fn offset_to_line() {
         let text = "a b c d ".into();
         let lines = make_lines(&text, 1.);

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -282,12 +282,11 @@ mod tests {
         assert_eq!(10, c.next::<BreaksMetric>().unwrap());
         assert!(c.next::<BreaksMetric>().is_none());
         c.set(0);
-        assert!(c.is_boundary::<BreaksMetric>());
+        assert!(!c.is_boundary::<BreaksMetric>());
         c.set(1);
         assert!(!c.is_boundary::<BreaksMetric>());
         c.set(10);
         assert!(c.is_boundary::<BreaksMetric>());
-        assert_eq!(0, c.prev::<BreaksMetric>().unwrap());
         assert!(c.prev::<BreaksMetric>().is_none());
     }
 

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -675,6 +675,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
     /// When there is no next boundary, returns `None` and the cursor becomes invalid.
     ///
     /// Return value: the position of the boundary, if it exists.
+    #[allow(clippy::question_mark)]
     pub fn next<M: Metric<N>>(&mut self) -> Option<(usize)> {
         if self.position >= self.root.len() || self.leaf.is_none() {
             self.leaf = None;

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -504,15 +504,43 @@ impl<N: NodeInfo> TreeBuilder<N> {
 
 const CURSOR_CACHE_SIZE: usize = 4;
 
+/// A data structure for traversing boundaries in a tree.
+///
+/// It is designed to be efficient both for random access and for iteration. The
+/// cursor itself is agnostic to which [`Metric`] is used to determine boundaries, but
+/// the methods to find boundaries are parametrized on the [`Metric`].
+///
+/// A cursor can be valid or invalid. It is always valid when created or after
+/// [`set`](#method.set) is called, and becomes invalid after [`prev`](#method.prev)
+/// or [`next`](#method.next) fails to find a boundary.
+///
+/// [`Metric`]: struct.Metric.html
 pub struct Cursor<'a, N: 'a + NodeInfo> {
+    /// The tree being traversed by this cursor.
     root: &'a Node<N>,
+    /// The current position of the cursor.
+    ///
+    /// It is always less than or equal to the tree length.
     position: usize,
+    /// The cache holds the tail of the path from the root to the current leaf.
+    ///
+    /// Each entry is a reference to the parent node and the index of the child. It
+    /// is stored bottom-up; `cache[0]` is the parent of the leaf and the index of
+    /// the leaf within that parent.
+    ///
+    /// The main motivation for this being a fixed-size array is to keep the cursor
+    /// an allocation-free data structure.
     cache: [Option<(&'a Node<N>, usize)>; CURSOR_CACHE_SIZE],
+    /// The leaf containing the current position, when the cursor is valid.
+    ///
+    /// The position is only at the end of the leaf when it is at the end of the tree.
     leaf: Option<&'a N::L>,
+    /// The offset of `leaf` within the tree.
     offset_of_leaf: usize,
 }
 
 impl<'a, N: NodeInfo> Cursor<'a, N> {
+    /// Create a new cursor at the given position.
     pub fn new(n: &'a Node<N>, position: usize) -> Cursor<'a, N> {
         let mut result = Cursor {
             root: n,
@@ -525,22 +553,30 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         result
     }
 
+    /// The length of the tree.
     pub fn total_len(&self) -> usize {
         self.root.len()
     }
 
-    /// Return the a reference to the root node.
+    /// Return a reference to the root node of the tree.
     pub fn root(&self) -> &'a Node<N> {
         self.root
     }
 
-    /// return value is leaf (if cursor is valid) and offset within leaf
+    /// Get the current leaf of the cursor.
     ///
-    /// invariant: offset is at end of leaf iff end of rope
+    /// If the cursor is valid, returns the leaf containing the current position,
+    /// and the offset of the current position within the leaf. That offset is equal
+    /// to the leaf length only at the end, otherwise it is less than the leaf length.
     pub fn get_leaf(&self) -> Option<(&'a N::L, usize)> {
         self.leaf.map(|l| (l, self.position - self.offset_of_leaf))
     }
 
+    /// Set the position of the cursor.
+    ///
+    /// The cursor is valid after this call.
+    ///
+    /// Precondition: `position` is less than or equal to the length of the tree.
     pub fn set(&mut self, position: usize) {
         self.position = position;
         if let Some(l) = self.leaf {
@@ -553,33 +589,40 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         self.descend();
     }
 
+    /// Get the position of the cursor.
     pub fn pos(&self) -> usize {
         self.position
     }
 
+    /// Determine whether the current position is a boundary.
+    ///
+    /// Note: the beginning and end of the tree may or may not be boundaries, depending on the
+    /// metric. If the metric is not `can_fragment`, then they always are.
     pub fn is_boundary<M: Metric<N>>(&mut self) -> bool {
         if self.leaf.is_none() {
             // not at a valid position
             return false;
         }
-        if self.position == 0 || (self.position == self.offset_of_leaf && !M::can_fragment()) {
+        if self.position == self.offset_of_leaf && !M::can_fragment() {
             return true;
         }
-        if self.position > self.offset_of_leaf {
+        if self.position == 0 || self.position > self.offset_of_leaf {
             return M::is_boundary(self.leaf.unwrap(), self.position - self.offset_of_leaf);
         }
         // tricky case, at beginning of leaf, need to query end of previous
         // leaf; TODO: would be nice if we could do it another way that didn't
-        // make the method &self mut.
+        // make the method &mut self.
         let l = self.prev_leaf().unwrap().0;
         let result = M::is_boundary(l, l.len());
         let _ = self.next_leaf();
         result
     }
 
-    /// Moves the cursor to the previous boundary, or to the beginning of the
-    /// rope. In the former case, returns the position of the first character
-    /// past this boundary. In the latter case, returns `0`.
+    /// Moves the cursor to the previous boundary.
+    ///
+    /// When there is no previous boundary, returns `None` and the cursor becomes invalid.
+    ///
+    /// Return value: the position of the boundary, if it exists.
     pub fn prev<M: Metric<N>>(&mut self) -> Option<(usize)> {
         if self.position == 0 || self.leaf.is_none() {
             self.leaf = None;
@@ -602,7 +645,7 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         loop {
             if self.offset_of_leaf == 0 {
                 self.position = 0;
-                return Some(self.position);
+                return None;
             }
             if let Some((l, _)) = self.prev_leaf() {
                 // TODO: node already has this, no need to recompute. But, we
@@ -627,9 +670,11 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         }
     }
 
-    /// Moves the cursor to the next boundary, or to the end of the rope. In the
-    /// former case, returns the position of the first character past this
-    /// boundary. In the latter case, returns the length of the rope.
+    /// Moves the cursor to the next boundary.
+    ///
+    /// When there is no next boundary, returns `None` and the cursor becomes invalid.
+    ///
+    /// Return value: the position of the boundary, if it exists.
     pub fn next<M: Metric<N>>(&mut self) -> Option<(usize)> {
         if self.position >= self.root.len() || self.leaf.is_none() {
             self.leaf = None;
@@ -645,18 +690,18 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
             for i in 0..CURSOR_CACHE_SIZE {
                 if self.cache[i].is_none() {
                     // we are at the root of the tree.
-                    return Some(self.root.len());
+                    return None;
                 }
                 let (node, j) = self.cache[i].unwrap();
-                let (next_j, offset) = node.next_positive_measure_child::<M>(j + 1);
-                self.position += offset;
+                let (next_j, skipped) = node.next_positive_measure_child::<M>(j + 1);
+                self.position += skipped;
                 if let Some(next_j) = next_j {
                     self.cache[i] = Some((node, next_j));
                     let mut node_down = &node.get_children()[next_j];
                     for k in (0..i).rev() {
-                        let (pm_child, offset) = node_down.next_positive_measure_child::<M>(0);
+                        let (pm_child, skipped) = node_down.next_positive_measure_child::<M>(0);
                         let pm_child = pm_child.unwrap(); // at least one child must have positive measure
-                        self.position += offset;
+                        self.position += skipped;
                         self.cache[k] = Some((node_down, pm_child));
                         node_down = &node_down.get_children()[pm_child];
                     }
@@ -668,9 +713,6 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
             // At this point, we know that (1) the next boundary is not not in
             // the cached subtree, (2) self.position corresponds to the begining
             // of the first leaf after the cached subtree.
-            if self.position == self.root.len() {
-                return Some(self.position);
-            }
             self.descend();
             return self.next::<M>();
         } else {
@@ -680,6 +722,8 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
 
     /// Returns the current position if it is a boundary in this [`Metric`],
     /// else behaves like [`next`](#method.next).
+    ///
+    /// [`Metric`]: struct.Metric.html
     pub fn at_or_next<M: Metric<N>>(&mut self) -> Option<usize> {
         if self.is_boundary::<M>() {
             Some(self.pos())
@@ -690,6 +734,8 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
 
     /// Returns the current position if it is a boundary in this [`Metric`],
     /// else behaves like [`prev`](#method.prev).
+    ///
+    /// [`Metric`]: struct.Metric.html
     pub fn at_or_prev<M: Metric<N>>(&mut self) -> Option<usize> {
         if self.is_boundary::<M>() {
             Some(self.pos())
@@ -708,15 +754,16 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
     /// let text: Rope = "one line\ntwo line\nred line\nblue".into();
     /// let mut cursor = Cursor::new(&text, 0);
     /// let line_offsets = cursor.iter::<LinesMetric>().collect::<Vec<_>>();
-    /// assert_eq!(line_offsets, vec![9, 18, 27, 31]);
+    /// assert_eq!(line_offsets, vec![9, 18, 27]);
     ///
     /// ```
+    /// [`Metric`]: struct.Metric.html
     pub fn iter<'c, M: Metric<N>>(&'c mut self) -> CursorIter<'c, 'a, N, M> {
         CursorIter { cursor: self, _metric: PhantomData }
     }
 
     /// Tries to find the next boundary in the leaf the cursor is currently in.
-    #[inline(always)]
+    #[inline]
     fn next_inside_leaf<M: Metric<N>>(&mut self) -> Option<usize> {
         if let Some(l) = self.leaf {
             let offset_in_leaf = self.position - self.offset_of_leaf;
@@ -730,24 +777,18 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
                 }
                 return Some(self.position);
             }
-            if self.offset_of_leaf + l.len() == self.root.len() {
-                self.position = self.root.len();
-                return Some(self.position);
-            }
         } else {
             panic!("inconsistent, shouldn't get here");
         }
         None
     }
 
-    /// same return as get_leaf, moves to beginning of next leaf
+    /// Move to beginning of next leaf.
+    ///
+    /// Return value: same as [`get_leaf`](#method.get_leaf).
     pub fn next_leaf(&mut self) -> Option<(&'a N::L, usize)> {
-        if let Some(leaf) = self.leaf {
-            self.position = self.offset_of_leaf + leaf.len();
-        } else {
-            self.leaf = None;
-            return None;
-        }
+        let leaf = self.leaf?;
+        self.position = self.offset_of_leaf + leaf.len();
         for i in 0..CURSOR_CACHE_SIZE {
             if self.cache[i].is_none() {
                 // this probably can't happen
@@ -775,14 +816,17 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         self.get_leaf()
     }
 
-    /// same return as get_leaf, moves to beginning of prev leaf
+    /// Move to beginning of previous leaf.
+    ///
+    /// Return value: same as [`get_leaf`](#method.get_leaf).
     pub fn prev_leaf(&mut self) -> Option<(&'a N::L, usize)> {
-        if self.offset_of_leaf == 0 || Some(self.leaf).is_none() {
+        if self.offset_of_leaf == 0 {
             self.leaf = None;
             return None;
         }
         for i in 0..CURSOR_CACHE_SIZE {
             if self.cache[i].is_none() {
+                // this probably can't happen
                 self.leaf = None;
                 return None;
             }
@@ -808,6 +852,10 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
         self.get_leaf()
     }
 
+    /// Find the leaf containing the current position.
+    ///
+    /// Sets `leaf` to the leaf containing `position`, and updates `cache` and
+    /// `offset_of_leaf` to be consistent.
     fn descend(&mut self) {
         let mut node = self.root;
         let mut offset = 0;
@@ -837,6 +885,9 @@ impl<'a, N: NodeInfo> Cursor<'a, N> {
 }
 
 /// An iterator generated by a [`Cursor`], for some [`Metric`].
+///
+/// [`Cursor`]: struct.Cursor.html
+/// [`Metric`]: struct.Metric.html
 pub struct CursorIter<'c, 'a: 'c, N: 'a + NodeInfo, M: 'a + Metric<N>> {
     cursor: &'c mut Cursor<'a, N>,
     _metric: PhantomData<&'a M>,
@@ -852,6 +903,8 @@ impl<'c, 'a, N: NodeInfo, M: Metric<N>> Iterator for CursorIter<'c, 'a, N, M> {
 
 impl<'c, 'a, N: NodeInfo, M: Metric<N>> CursorIter<'c, 'a, N, M> {
     /// Returns the current position of the underlying [`Cursor`].
+    ///
+    /// [`Cursor`]: struct.Cursor.html
     pub fn pos(&self) -> usize {
         self.cursor.pos()
     }
@@ -980,8 +1033,8 @@ mod test {
     fn at_or_next() {
         let text: Rope = "this\nis\nalil\nstring".into();
         let mut cursor = Cursor::new(&text, 0);
-        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(0));
-        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(0));
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(5));
+        assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(5));
         cursor.set(1);
         assert_eq!(cursor.at_or_next::<LinesMetric>(), Some(5));
         assert_eq!(cursor.at_or_prev::<LinesMetric>(), Some(5));
@@ -998,7 +1051,7 @@ mod test {
         for _ in 0..24 {
             text = Node::concat(text.clone(), text);
             let mut cursor = Cursor::new(&text, 0);
-            assert_eq!(cursor.next::<LinesMetric>(), Some(text.len()));
+            assert_eq!(cursor.next::<LinesMetric>(), None);
         }
     }
 }


### PR DESCRIPTION
Previously, a cursor would always consider the 0 and EOF (e.g. `tree.len()`) positions to be boundaries, regardless of what metric was used. With this change, whether those positions are considered boundaries is left up to the particular metric.

This also includes substantial new documentation for the new behaviour.

closes #1050 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
