### PR TITLE
Refactor gestures

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -153,39 +153,26 @@ Notifies the backend that the size of the view has changed. This is
 used for word wrapping, if enabled. Width and height are specified
 in px units / points, not display pixels.
 
-#### click
-
-`click [42,31,0,1]`
-
-Implements a mouse click. The array arguments are: line and column
-(0-based, utf-8 code units), modifiers (again, 2 is shift), and
-click count.
-
-#### drag
-
-`drag [42,32,0]`
-
-Implements dragging (extending a selection). Arguments are line,
-column, and flag as in `click`.
-
 #### gesture
 
-`gesture {"line": 42, "col": 31, "ty": "toggle_sel"}`
+`gesture {"line": 42, "col": 31, "ty": {"select": {"granularity": "point", "multi": false}}`
 
-**Note:** both `click` and `drag` functionality will be migrated to
-additional `ty` options for `gesture`.
-
-Currently, the following gestures are supported:
+Gestures correspond to certain pointer events on the text window. Currently, the following gesture types are supported:
 
 ```
-point_select # moves the cursor to a point
-toggle_sel # adds or removes a selection at a point
-range_select # modifies the selection to include a point (shift+click)
-line_select # sets the selection to a given line
-word_select # sets the selection to a given word
-multi_line_select # adds a line to the selection
-multi_word_select # adds a word to the selection
+{"select": {"granularity": "point", "multi": false}}
 ```
+Adds a new selection region, preserving existing regions if `multi` is `true`. Granularity can be one of `"point"`, `"word"`, or `"line"`.
+
+```
+{"select_extend": {"granularity": "point"}}
+```
+Modifies the selection to include a location. This gesture is usually mapped to shift+click on the frontend. Granularity can be one of `"point"`, `"word"`, or `"line"`.
+
+```
+"drag"
+```
+Extends the selection to the mouse's new location. Granularity is determined by the preceding `select` gesture.
 
 #### goto_line
 

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -291,10 +291,27 @@ pub struct EditCommand<T> {
     pub cmd: T,
 }
 
+/// The smallest unit of text that a gesture can select
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectionGranularity {
+    /// Selects any point or character range
+    Point,
+    /// Selects one word at a time
+    Word,
+    /// Selects one line at a time
+    Line,
+}
+
 /// An enum representing touch and mouse gestures applied to the text.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum GestureType {
+    Select { granularity: SelectionGranularity, multi: bool },
+    SelectExtend { granularity: SelectionGranularity },
+    Drag,
+
+    // Deprecated
     PointSelect,
     ToggleSel,
     RangeSelect,

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -358,6 +358,12 @@ impl<'a> From<&'a SelRegion> for Interval {
     }
 }
 
+impl From<Interval> for SelRegion {
+    fn from(src: Interval) -> SelRegion {
+        SelRegion::new(src.start, src.end)
+    }
+}
+
 impl From<SelRegion> for Selection {
     fn from(region: SelRegion) -> Self {
         Self::new_simple(region)

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -276,34 +276,8 @@ impl View {
             }
             GestureType::Drag => self.do_drag(text, offset, Affinity::default()),
 
-            // Deprecated gestures, kept for compatibility
-            GestureType::PointSelect => {
-                warn!("The point_select gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Point, false)
-            }
-            GestureType::RangeSelect => {
-                warn!("The range_select gesture is deprecated; use select_extend instead");
-                self.extend_selection(text, offset, SelectionGranularity::Point)
-            }
-            GestureType::ToggleSel => {
-                warn!("The toggle_sel gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Point, true)
-            }
-            GestureType::LineSelect => {
-                warn!("The line_select gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Line, false)
-            }
-            GestureType::WordSelect => {
-                warn!("The word_select gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Word, false)
-            }
-            GestureType::MultiLineSelect => {
-                warn!("The multi_line_select gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Line, true)
-            }
-            GestureType::MultiWordSelect => {
-                warn!("The multi_word_select gesture is deprecated; use select instead");
-                self.select(text, offset, SelectionGranularity::Word, true)
+            _ => {
+                warn!("Deprecated gesture type sent to do_gesture method");
             }
         }
     }


### PR DESCRIPTION
## Summary
This is part 1 of some refactoring related to the selection commands. I'm focusing on gestures first; hopefully by the time this is merged I'll have a clearer idea of what to do about movements.

### Behavior changes
This is mostly about cleaning up internals, but a few changes will be visible from the frontend.
* Previously, xi would keep existing selections when the you pressed shift+click (unlike TextEdit), but they disappeared as soon as you started dragging. This pull request preserves them after you start dragging.
* RangeSelect now takes a granularity argument (e.g. for shift + double-click).
* Dragging with a granularity won't reverse the selection until you move a whole unit backwards. This one's a little hard to explain, but double-click in the middle of a long word and move the mouse a couple pixels to the left. The current version will move the cursor to the start of the SelRegion; this PR won't. Most other editors seem to do it this way, and it simplifies the code a bit.

## Related Issues
Discussed in #826.

## To do
- [x] Submit pull request to xi-mac (xi-editor/xi-mac#408)
- [x] Support old version of the protocol
- [x] Update documentation
- [ ] Test

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.