### PR TITLE
fix: ensure exec_path appends .exe on windows

### DIFF
--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -16,7 +16,7 @@
 
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{self, Value};
 
 use crate::syntax::{LanguageDefinition, LanguageId};
@@ -33,6 +33,7 @@ pub struct PluginDescription {
     pub scope: PluginScope,
     // more metadata ...
     /// path to plugin executable
+    #[serde(deserialize_with = "platform_exec_path")]
     pub exec_path: PathBuf,
     /// Events that cause this plugin to run
     #[serde(default)]
@@ -41,6 +42,15 @@ pub struct PluginDescription {
     pub commands: Vec<Command>,
     #[serde(default)]
     pub languages: Vec<LanguageDefinition>,
+}
+
+fn platform_exec_path<'de, D: Deserializer<'de>>(deserializer: D) -> Result<PathBuf, D::Error> {
+    let exec_path = PathBuf::deserialize(deserializer)?;
+    if cfg!(windows) {
+        Ok(exec_path.with_extension("txt"))
+    } else {
+        Ok(exec_path)
+    }
 }
 
 /// `PluginActivation`s represent events that trigger running a plugin.

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -47,7 +47,7 @@ pub struct PluginDescription {
 fn platform_exec_path<'de, D: Deserializer<'de>>(deserializer: D) -> Result<PathBuf, D::Error> {
     let exec_path = PathBuf::deserialize(deserializer)?;
     if cfg!(windows) {
-        Ok(exec_path.with_extension("txt"))
+        Ok(exec_path.with_extension("exe"))
     } else {
         Ok(exec_path)
     }
@@ -236,6 +236,28 @@ impl Default for PluginScope {
 mod tests {
     use super::*;
     use serde_json;
+
+    #[test]
+    fn platform_exec_path() {
+        let json = r#"
+        {
+            "name": "test_plugin",
+            "version": "0.0.0",
+            "scope": "global",
+            "exec_path": "path/to/binary",
+            "activations": [],
+            "commands": [],
+            "languages": []
+        }
+        "#;
+
+        let plugin_desc: PluginDescription = serde_json::from_str(&json).unwrap();
+        if cfg!(windows) {
+            assert!(plugin_desc.exec_path.ends_with("binary.exe"));
+        } else {
+            assert!(plugin_desc.exec_path.ends_with("binary"));
+        }
+    }
 
     #[test]
     fn test_serde_command() {


### PR DESCRIPTION
Fixes #1074.

This PR ensures that when each plugin's `manifest.toml` is deserialised so that the `exec_path` has the `.exe` extension on windows platforms.