### PR TITLE
mark xi-mac as ready for daily use

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ To build the xi-editor core from the root directory of this repo:
 
 ## Frontends
 
-Here are some front-ends in various stages of development:
+Following frontends are ready for daily use as the editor:
 
 * [xi-mac](https://github.com/xi-editor/xi-mac), the official macOS front-end.
+
+Here are some front-ends in various stages of development, based on current versions of the front-end protocol, but not ready for a daily use:
 
 * [fuchsia/xi](https://fuchsia.googlesource.com/topaz/+/master/bin/xi/), a front-end in Flutter for Fuchsia.
 


### PR DESCRIPTION
## Summary

this is an attempt to make readme useful for people looking for an editor (uninterested in developing a new editor but the may be still useful as bug reporters)
based on comments in https://github.com/xi-editor/xi-editor/pull/1073
note that maybe also some other editors are also ready for daily use - let me know and I will update this PR



<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
* Related to #816 
* Replaces #1073

## Checklist

not applicable

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate (not yet applicabble).
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks` (not applicable).
- [x] I have updated comments / documentation related to the changes I made (not applicable).
- [x] I have rebased my PR branch onto xi-editor/master (not yet applicable).
