### PR TITLE
fix: move to end of paragraph was not working on last line without newline

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -742,6 +742,14 @@ mod tests {
         let harness = ContextHarness::new(initial_text);
         let mut ctx = harness.make_context();
 
+        ctx.do_edit(EditNotification::MoveDown);
+        ctx.do_edit(EditNotification::MoveDown);
+        ctx.do_edit(EditNotification::MoveToEndOfParagraph);
+        assert_eq!(harness.debug_render(),"\
+        this is a string\n\
+        that has three\n\
+        lines.|" );
+
         ctx.do_edit(EditNotification::Gesture { line: 0, col: 0, ty: PointSelect });
         ctx.do_edit(EditNotification::MoveToEndOfParagraphAndModifySelection);
         assert_eq!(harness.debug_render(),"\

--- a/rust/core-lib/src/movement.rs
+++ b/rust/core-lib/src/movement.rs
@@ -248,8 +248,11 @@ pub fn region_movement(
                 } else if cursor.pos() == text.len() {
                     offset = text.len();
                 }
+                (offset, None)
+            } else {
+                //in this case we are already on a last line so just moving to EOL
+                (text.len(), None)
             }
-            (offset, None)
         }
         Movement::EndOfParagraphKill => {
             // Note: TextEdit would start at modify ? r.end : r.max()


### PR DESCRIPTION
## Summary
Fixes bug when goto end of line was not working for the last line


## Related Issues
closes #1081 

## Checklist


- [x] Add regression test for described case
- [x] Add actual fix for the issue

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
