### PR TITLE
Point to fork of GXI, upstream is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Here are some front-ends in various stages of development:
 
 * [xi-electron](https://github.com/acheronfail/xi-electron), a cross-platform front-end based on web-technologies.
 
-* [gxi](https://github.com/bvinc/gxi), a GTK+ front-end written in Rust.
+* [gxi](https://github.com/Cogitri/gxi), a GTK+ front-end written in Rust. Forked from https://github.com/bvinc/gxi, which was abandoned.
 
 * [xi-win](https://github.com/xi-editor/xi-win), an experimental Windows front-end written in Rust.
 


### PR DESCRIPTION
The fork has just published a new release and should be good to go for general usage. See https://github.com/Cogitri/gxi/releases/tag/v0.3.0

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
