### PR TITLE
Only check for x86 features on x86_64

### DIFF
--- a/rust/rope/src/compare.rs
+++ b/rust/rope/src/compare.rs
@@ -16,6 +16,7 @@
 use crate::rope::{BaseMetric, Rope, RopeInfo};
 use crate::tree::Cursor;
 
+#[allow(dead_code)]
 const SSE_STRIDE: usize = 16;
 
 /// Given two 16-byte slices, returns a bitmask where the 1 bits indicate
@@ -56,6 +57,7 @@ pub unsafe fn sse_compare_mask(one: &[u8], two: &[u8]) -> i32 {
     (!_mm_movemask_epi8(mask)) ^ HIGH_HALF_MASK as i32
 }
 
+#[allow(dead_code)]
 const AVX_STRIDE: usize = 32;
 
 /// Like above but with 32 byte slices
@@ -73,23 +75,27 @@ pub unsafe fn avx_compare_mask(one: &[u8], two: &[u8]) -> i32 {
 
 /// Returns the lowest `i` for which `one[i] != two[i]`, if one exists.
 pub fn ne_idx(one: &[u8], two: &[u8]) -> Option<usize> {
-    if is_x86_feature_detected!("avx2") {
-        unsafe { ne_idx_avx(one, two) }
-    } else if is_x86_feature_detected!("sse4.2") {
-        unsafe { ne_idx_sse(one, two) }
-    } else {
-        ne_idx_fallback(one, two)
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return unsafe { ne_idx_avx(one, two) };
+        } else if is_x86_feature_detected!("sse4.2") {
+            return unsafe { ne_idx_sse(one, two) };
+        }
     }
+    ne_idx_fallback(one, two)
 }
 
 /// Returns the lowest `i` such that `one[one.len()-i] != two[two.len()-i]`,
 /// if one exists.
 pub fn ne_idx_rev(one: &[u8], two: &[u8]) -> Option<usize> {
-    if is_x86_feature_detected!("sse4.2") {
-        unsafe { ne_idx_rev_sse(one, two) }
-    } else {
-        ne_idx_rev_fallback(one, two)
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("sse4.2") {
+            return unsafe { ne_idx_rev_sse(one, two) };
+        }
     }
+    ne_idx_rev_fallback(one, two)
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
This fixes an issue where when compiled for x86 (i686) we might
try to call a function that had not actually been compiled.

This brings up an obvious question, which is whether we should be
using at avx2/sse4.2 on i686? My understanding was that no i686
processors existed with avx2 support, and only a couple with sse4.2,
and so this didn't really feel worth it at the time.

- fixes #1097

@Cogitri I don't imagine you have any way to test this?


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
