### PR TITLE
Bugfix: return None when detected tab_size in file is 0

### DIFF
--- a/rust/core-lib/src/whitespace.rs
+++ b/rust/core-lib/src/whitespace.rs
@@ -59,7 +59,7 @@ impl Indentation {
                 } else {
                     Ok(None)
                 }
-            },
+            }
             _ => Ok(None),
         }
     }
@@ -191,5 +191,17 @@ mod tests {
         let expected = Indentation::Spaces(4);
 
         assert_eq!(result.unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn rope_returns_none() {
+        let result = Indentation::parse(&Rope::from(
+            r#"# Readme example
+ 1. One space.
+But the majority is still 0.
+"#,
+        ));
+
+        assert_eq!(result.unwrap(), None);
     }
 }

--- a/rust/core-lib/src/whitespace.rs
+++ b/rust/core-lib/src/whitespace.rs
@@ -52,7 +52,14 @@ impl Indentation {
         match (tabs, !spaces.is_empty()) {
             (true, true) => Err(MixedIndentError),
             (true, false) => Ok(Some(Indentation::Tabs)),
-            (false, true) => Ok(Some(Indentation::Spaces(extract_count(spaces)))),
+            (false, true) => {
+                let tab_size = extract_count(spaces);
+                if tab_size > 0 {
+                    Ok(Some(Indentation::Spaces(tab_size)))
+                } else {
+                    Ok(None)
+                }
+            },
             _ => Ok(None),
         }
     }


### PR DESCRIPTION
This fixes https://github.com/xi-editor/xi-editor/issues/1091

The problem was that for each line the indentation level is determined and if at least one line has some indentation then the indentation level is returned. The returned indentation level is the one most frequently used in the file. So if there is, for example, one line with indentation level >0 and all other lines don't have indentation then it returns 0 instead of `None`.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
