### PR TITLE
Syntax detection fails for git commit messages #1096

### DIFF
--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -127,9 +127,6 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn language_for_name() {}
-
-    #[test]
     pub fn language_for_path() {
         let ld_rust = LanguageDefinition {
             name: LanguageId::from("Rust"),

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -122,43 +122,50 @@ impl LanguageDefinition {
     }
 }
 
-// for testing
 #[cfg(test)]
-pub fn language_for_name() {}
+mod tests {
+    use super::*;
 
-#[cfg(test)]
-pub fn language_for_path() {
-    let ld_rust = LanguageDefinition {
-        name: LanguageId::from("Rust"),
-        extensions: vec![String::from("rs")],
-        scope: String::from("source.rust"),
-        first_line_match: None,
-        default_config: None,
-    };
-    let ld_commit_msg = LanguageDefinition {
-        name: LanguageId::from("Git Commit"),
-        extensions: vec![
-            String::from("COMMIT_EDITMSG"),
-            String::from("MERGE_MSG"),
-            String::from("TAG_EDITMSG"),
-        ],
-        scope: String::from("text.git.commit"),
-        first_line_match: None,
-        default_config: None,
-    };
-    let languages = Languages::new(&[ld_rust.clone(), ld_commit_msg.clone()]);
+    #[test]
+    pub fn language_for_name() {}
 
-    assert_eq!(ld_rust.name, languages.language_for_path(Path::new("/path/test.rs")).unwrap().name);
-    assert_eq!(
-        ld_commit_msg.name,
-        languages.language_for_path(Path::new("/path/COMMIT_EDITMSG")).unwrap().name
-    );
-    assert_eq!(
-        ld_commit_msg.name,
-        languages.language_for_path(Path::new("/path/MERGE_MSG")).unwrap().name
-    );
-    assert_eq!(
-        ld_commit_msg.name,
-        languages.language_for_path(Path::new("/path/TAG_EDITMSG")).unwrap().name
-    );
+    #[test]
+    pub fn language_for_path() {
+        let ld_rust = LanguageDefinition {
+            name: LanguageId::from("Rust"),
+            extensions: vec![String::from("rs")],
+            scope: String::from("source.rust"),
+            first_line_match: None,
+            default_config: None,
+        };
+        let ld_commit_msg = LanguageDefinition {
+            name: LanguageId::from("Git Commit"),
+            extensions: vec![
+                String::from("COMMIT_EDITMSG"),
+                String::from("MERGE_MSG"),
+                String::from("TAG_EDITMSG"),
+            ],
+            scope: String::from("text.git.commit"),
+            first_line_match: None,
+            default_config: None,
+        };
+        let languages = Languages::new(&[ld_rust.clone(), ld_commit_msg.clone()]);
+
+        assert_eq!(
+            ld_rust.name,
+            languages.language_for_path(Path::new("/path/test.rs")).unwrap().name
+        );
+        assert_eq!(
+            ld_commit_msg.name,
+            languages.language_for_path(Path::new("/path/COMMIT_EDITMSG")).unwrap().name
+        );
+        assert_eq!(
+            ld_commit_msg.name,
+            languages.language_for_path(Path::new("/path/MERGE_MSG")).unwrap().name
+        );
+        assert_eq!(
+            ld_commit_msg.name,
+            languages.language_for_path(Path::new("/path/TAG_EDITMSG")).unwrap().name
+        );
+    }
 }

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -61,9 +61,16 @@ impl Languages {
     }
 
     pub fn language_for_path(&self, path: &Path) -> Option<Arc<LanguageDefinition>> {
-        path.extension()
-            .and_then(|ext| self.extensions.get(ext.to_str().unwrap_or_default()))
-            .map(Arc::clone)
+        match path.extension() {
+            Some(_) => path
+                .extension()
+                .and_then(|ext| self.extensions.get(ext.to_str().unwrap_or_default()))
+                .map(Arc::clone),
+            None => path
+                .file_name()
+                .and_then(|name| self.extensions.get(name.to_str().unwrap_or_default()))
+                .map(Arc::clone),
+        }
     }
 
     pub fn language_for_name<S>(&self, name: S) -> Option<Arc<LanguageDefinition>>
@@ -120,3 +127,7 @@ impl LanguageDefinition {
         }
     }
 }
+
+// for testing
+#[cfg(test)]
+pub fn language_for_name() {}


### PR DESCRIPTION
Hey here's something I have come up with to issue #1096. 
- [x] Syntax detection fails for files without extensions.
- [ ] Tests

Can someone help me with the tests for this one?