### PR TITLE
Automatically delete and load new/modified plugins

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -546,6 +546,22 @@ impl ConfigManager {
         }
         None
     }
+
+    /// Path to plugins sub directory inside config directory.
+    /// Creates one if not present.
+    pub(crate) fn get_plugins_dir(&self) -> Option<PathBuf> {
+        let plugins_dir = self.config_dir.as_ref().map(|p| p.join("plugins"));
+
+        if let Some(p) = plugins_dir {
+            if p.exists() {
+                return Some(p);
+            }
+            if fs::DirBuilder::new().create(&p).is_ok() {
+                return Some(p);
+            }
+        }
+        None
+    }
 }
 
 impl TableStack {

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -48,6 +48,11 @@ impl<'a> PluginCatalog {
     pub fn reload_from_paths(&mut self, paths: &[PathBuf]) {
         self.items.clear();
         self.locations.clear();
+        self.load_from_paths(paths);
+    }
+
+    /// Loads plugins from paths and adds them to existing plugins.
+    pub fn load_from_paths(&mut self, paths: &[PathBuf]) {
         let all_manifests = find_all_manifests(paths);
         for manifest_path in &all_manifests {
             match load_manifest(manifest_path) {
@@ -79,9 +84,21 @@ impl<'a> PluginCatalog {
         self.items.keys()
     }
 
+    /// Returns the plugin located at the provided file path.
+    pub fn get_from_path(&self, path: &PathBuf) -> Option<Arc<PluginDescription>> {
+        self.items.values().find(|&v| {
+            v.exec_path.to_str().unwrap().contains(path.to_str().unwrap())
+        }).map(|plugin| plugin.clone())
+    }
+
     /// Returns a reference to the named plugin if it exists in the catalog.
     pub fn get_named(&self, plugin_name: &str) -> Option<Arc<PluginDescription>> {
         self.items.get(plugin_name).map(Arc::clone)
+    }
+
+    /// Removes the named plugin.
+    pub fn remove_named(&mut self, plugin_name: &str) {
+        self.items.remove(plugin_name);
     }
 }
 

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -85,12 +85,11 @@ impl<'a> PluginCatalog {
     }
 
     /// Returns the plugin located at the provided file path.
-    #[allow(clippy::map_clone)]
     pub fn get_from_path(&self, path: &PathBuf) -> Option<Arc<PluginDescription>> {
         self.items
             .values()
             .find(|&v| v.exec_path.to_str().unwrap().contains(path.to_str().unwrap()))
-            .map(|plugin| plugin.clone())
+            .cloned()
     }
 
     /// Returns a reference to the named plugin if it exists in the catalog.

--- a/rust/core-lib/src/plugins/catalog.rs
+++ b/rust/core-lib/src/plugins/catalog.rs
@@ -85,10 +85,12 @@ impl<'a> PluginCatalog {
     }
 
     /// Returns the plugin located at the provided file path.
+    #[allow(clippy::map_clone)]
     pub fn get_from_path(&self, path: &PathBuf) -> Option<Arc<PluginDescription>> {
-        self.items.values().find(|&v| {
-            v.exec_path.to_str().unwrap().contains(path.to_str().unwrap())
-        }).map(|plugin| plugin.clone())
+        self.items
+            .values()
+            .find(|&v| v.exec_path.to_str().unwrap().contains(path.to_str().unwrap()))
+            .map(|plugin| plugin.clone())
     }
 
     /// Returns a reference to the named plugin if it exists in the catalog.

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -36,13 +36,13 @@ use xi_rpc::{self, ReadError, RemoteError, RpcCtx, RpcPeer};
 use xi_trace::{self, trace_block};
 
 use crate::client::Client;
-use crate::plugins::rpc::ClientPluginInfo;
 use crate::config::{self, ConfigDomain, ConfigDomainExternal, ConfigManager, Table};
 use crate::editor::Editor;
 use crate::event_context::EventContext;
 use crate::file::FileManager;
 use crate::line_ending::LineEnding;
 use crate::plugin_rpc::{PluginNotification, PluginRequest};
+use crate::plugins::rpc::ClientPluginInfo;
 use crate::plugins::{start_plugin_process, Plugin, PluginCatalog, PluginPid};
 use crate::recorder::Recorder;
 use crate::rpc::{
@@ -162,9 +162,7 @@ impl CoreState {
         let plugins_dir = config_manager.get_plugins_dir();
         if let Some(p) = plugins_dir.as_ref() {
             #[cfg(feature = "notify")]
-                watcher.watch_filtered(p, true, PLUGIN_EVENT_TOKEN, |p| {
-                p.is_dir() || !p.exists()
-            });
+            watcher.watch_filtered(p, true, PLUGIN_EVENT_TOKEN, |p| p.is_dir() || !p.exists());
         }
 
         CoreState {
@@ -755,7 +753,7 @@ impl CoreState {
                 if let Some(plugin) = self.plugins.get_from_path(path) {
                     self.do_start_plugin(ViewId(0), &plugin.name);
                 }
-            },
+            }
             // the way FSEvents on macOS work, we want to verify that this path
             // has actually be removed before we do anything.
             NoticeRemove(ref path) | Remove(ref path) if !path.exists() => {
@@ -763,10 +761,10 @@ impl CoreState {
                     self.do_stop_plugin(ViewId(0), &plugin.name);
                     self.plugins.remove_named(&plugin.name);
                 }
-            },
+            }
             Rename(ref old, ref new) => {
                 if let Some(old_plugin) = self.plugins.get_from_path(old) {
-                    self.do_stop_plugin( ViewId(0), &old_plugin.name);
+                    self.do_stop_plugin(ViewId(0), &old_plugin.name);
                     self.plugins.remove_named(&old_plugin.name);
                 }
 
@@ -777,7 +775,7 @@ impl CoreState {
             }
             Chmod(ref path) | Remove(ref path) => {
                 if let Some(plugin) = self.plugins.get_from_path(path) {
-                    self.do_stop_plugin( ViewId(0), &plugin.name);
+                    self.do_stop_plugin(ViewId(0), &plugin.name);
                     self.do_start_plugin(ViewId(0), &plugin.name);
                 }
             }
@@ -785,7 +783,7 @@ impl CoreState {
         }
 
         self.views.keys().for_each(|view_id| {
-            let available_plugins =  self
+            let available_plugins = self
                 .plugins
                 .iter()
                 .map(|plugin| ClientPluginInfo { name: plugin.name.clone(), running: true })


### PR DESCRIPTION
I started working on some plugin stuff and noticed that new plugins added to the plugin directory and modified plugins don't get loaded automatically. So this PR adds this functionality. Also deleted plugins get removed from the editor.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
