### PR TITLE
Add newline to end of file if nonexistent

### DIFF
--- a/rust/core-lib/assets/client_example.toml
+++ b/rust/core-lib/assets/client_example.toml
@@ -39,3 +39,6 @@ word_wrap = false
 
 # Detect tab and newline settings on file open
 autodetect_whitespace = true
+
+# Ensure file ends in a newline when saving
+save_with_newline = true

--- a/rust/core-lib/assets/defaults.toml
+++ b/rust/core-lib/assets/defaults.toml
@@ -33,3 +33,5 @@ surrounding_pairs = [
   ["{", "}"],
   ["[", "]"],
 ]
+
+save_with_newline = true

--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -186,6 +186,7 @@ pub struct BufferItems {
     pub word_wrap: bool,
     pub autodetect_whitespace: bool,
     pub surrounding_pairs: Vec<(String, String)>,
+    pub save_with_newline: bool,
 }
 
 pub type BufferConfig = Config<BufferItems>;

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 
 use serde_json::{self, Value};
 
-use xi_rope::{Interval, LinesMetric, Rope, RopeDelta};
+use xi_rope::{Cursor, Interval, LinesMetric, Rope, RopeDelta};
 use xi_rpc::{Error as RpcError, RemoteError};
 use xi_trace::trace_block;
 
@@ -492,6 +492,32 @@ impl<'a> EventContext<'a> {
             Err(err) => error!("plugin shutdown, do something {:?}", err),
         }
         self.editor.borrow_mut().dec_revs_in_flight();
+    }
+
+    /// Returns the text to be saved, appending a newline if necessary.
+    pub(crate) fn text_for_save(&mut self) -> Rope {
+        let editor = self.editor.borrow();
+        let mut rope = editor.get_buffer().clone();
+        let rope_len = rope.len();
+
+        if rope_len < 1 || !self.config.save_with_newline {
+            return rope;
+        }
+
+        let cursor = Cursor::new(&rope, rope.len());
+        let has_newline_at_eof = match cursor.get_leaf() {
+            Some((last_chunk, _)) => last_chunk.ends_with(&self.config.line_ending),
+            // The rope can't be empty, since we would have returned earlier if it was
+            None => unreachable!(),
+        };
+
+        if !has_newline_at_eof {
+            let line_ending = &self.config.line_ending;
+            rope.edit(rope_len.., line_ending);
+            rope
+        } else {
+            rope
+        }
     }
 
     /// Called after anything changes that effects word wrap, such as the size of

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -390,9 +390,10 @@ impl CoreState {
             None => return,
         };
 
-        let ed = &self.editors[&buffer_id];
+        let mut save_ctx = self.make_context(view_id).unwrap();
+        let fin_text = save_ctx.text_for_save();
 
-        if let Err(e) = self.file_manager.save(path, ed.borrow().get_buffer(), buffer_id) {
+        if let Err(e) = self.file_manager.save(path, &fin_text, buffer_id) {
             let error_message = e.to_string();
             error!("File error: {:?}", error_message);
             self.peer.alert(error_message);


### PR DESCRIPTION
## Summary
Right now xi-editor doesn't add a newline at the end of files. This makes for rather ugly diffs 
(since the final line, that doesn't have a newline at its end also is recognized as changed). This PR changes this behavior and adds a newline if the file doesn't end in one already.

## Related Issues
fixes #1093

What this still needs:

- [x] Fix getting the last line