### PR TITLE
Allow plugins to subscribe to core events

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -381,6 +381,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +981,22 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strum_macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1282,8 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum_macros 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1469,6 +1495,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum inotify 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b54539f3910d6f84fbf9a643efd6e3aa6e4f001426c0329576128255994718"
@@ -1541,6 +1568,8 @@ dependencies = [
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum strum 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6b3fc98c482ff9bb37a6db6a6491218c4c82bec368bd5682033e5b96b969143"
+"checksum strum_macros 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6969d7021d96b53b12b774d4f412026f1debe7f168a0b8c59e93b4c1e850a05f"
 "checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum syntect 3.0.2 (git+https://github.com/trishume/syntect.git)" = "<none>"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -17,6 +17,8 @@ toml = "0.4"
 notify = { optional = true, version = "4.0" }
 regex = "1.0"
 memchr = "2.0.1"
+strum = "0.13.0"
+strum_macros = "0.13.0"
 
 xi-trace = { path = "../trace", version = "0.1.0" }
 xi-trace-dump = { path = "../trace-dump", version = "0.1.0" }

--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -163,6 +163,20 @@ impl WeakXiCore {
             core.inner().plugin_update(plugin, view, response);
         }
     }
+
+    /// Subscribes plugin to specified RPC event.
+    pub fn plugin_subscribe(&self, plugin: PluginId, rpc_method: &str) {
+        if let Some(core) = self.upgrade() {
+            core.inner().plugin_subscribe(plugin, rpc_method)
+        }
+    }
+
+    /// Removes RPC event subscriptions for plugin.
+    pub fn plugin_unsubscribe(&self, plugin: PluginId, rpc_method: &str) {
+        if let Some(core) = self.upgrade() {
+            core.inner().plugin_unsubscribe(plugin, rpc_method)
+        }
+    }
 }
 
 /// Handler for messages originating from plugins.

--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -163,20 +163,6 @@ impl WeakXiCore {
             core.inner().plugin_update(plugin, view, response);
         }
     }
-
-    /// Subscribes plugin to specified RPC event.
-    pub fn plugin_subscribe(&self, plugin: PluginId, rpc_method: &str) {
-        if let Some(core) = self.upgrade() {
-            core.inner().plugin_subscribe(plugin, rpc_method)
-        }
-    }
-
-    /// Removes RPC event subscriptions for plugin.
-    pub fn plugin_unsubscribe(&self, plugin: PluginId, rpc_method: &str) {
-        if let Some(core) = self.upgrade() {
-            core.inner().plugin_unsubscribe(plugin, rpc_method)
-        }
-    }
 }
 
 /// Handler for messages originating from plugins.

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -242,6 +242,8 @@ impl<'a> EventContext<'a> {
             }
             RemoveStatusItem { key } => self.client.remove_status_item(self.view_id, &key),
             ShowHover { request_id, result } => self.do_show_hover(request_id, result),
+            Subscribe { rpc_method } => self.weak_core.plugin_subscribe(plugin, &rpc_method),
+            Unsubscribe { rpc_method } => self.weak_core.plugin_unsubscribe(plugin, &rpc_method),
         };
         self.after_edit(&plugin.to_string());
         self.render_if_needed();

--- a/rust/core-lib/src/lib.rs
+++ b/rust/core-lib/src/lib.rs
@@ -47,6 +47,10 @@ extern crate syntect;
 extern crate time;
 extern crate toml;
 
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
+
 extern crate xi_rope;
 extern crate xi_rpc;
 extern crate xi_trace;

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -150,6 +150,15 @@ impl Plugin {
         )
     }
 
+    pub fn dispatch_core_notification(&self, core_notification: &Value) {
+        self.peer.send_rpc_notification(
+            "core_notification",
+            &json!({
+                "notification": core_notification,
+            }),
+        )
+    }
+
     pub fn dispatch_command(&self, view_id: ViewId, method: &str, params: &Value) {
         self.peer.send_rpc_notification(
             "custom_command",

--- a/rust/core-lib/src/plugins/mod.rs
+++ b/rust/core-lib/src/plugins/mod.rs
@@ -150,9 +150,9 @@ impl Plugin {
         )
     }
 
-    pub fn dispatch_core_notification(&self, core_notification: &Value) {
+    pub fn dispatch_subscribed_notification(&self, core_notification: &Value) {
         self.peer.send_rpc_notification(
-            "core_notification",
+            "subscribed_notification",
             &json!({
                 "notification": core_notification,
             }),

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -114,7 +114,7 @@ pub enum HostNotification {
     TracingConfig { enabled: bool },
     LanguageChanged { view_id: ViewId, new_lang: LanguageId },
     CustomCommand { view_id: ViewId, method: String, params: Value },
-    SubscribedNotification { view_id: ViewId, notification: Value },
+    SubscribedNotification { notification: Value },
 }
 
 // ====================================================================

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -114,6 +114,7 @@ pub enum HostNotification {
     TracingConfig { enabled: bool },
     LanguageChanged { view_id: ViewId, new_lang: LanguageId },
     CustomCommand { view_id: ViewId, method: String, params: Value },
+    SubscribedNotification { view_id: ViewId, notification: Value },
 }
 
 // ====================================================================
@@ -187,6 +188,8 @@ pub enum PluginNotification {
     UpdateStatusItem { key: String, value: String },
     RemoveStatusItem { key: String },
     ShowHover { request_id: usize, result: Result<Hover, RemoteError> },
+    Subscribe { rpc_method: String },
+    Unsubscribe { rpc_method: String },
 }
 
 /// Range expressed in terms of PluginPosition. Meant to be sent from

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -90,6 +90,7 @@ pub struct EmptyStruct {}
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+#[derive(ToString)]
 pub enum CoreNotification {
     /// The 'edit' namespace, for view-specific editor actions.
     ///
@@ -370,6 +371,7 @@ pub struct FindQuery {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
+#[derive(ToString)]
 pub enum EditNotification {
     Insert {
         chars: String,
@@ -569,7 +571,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for EditCommand<T> {
             Some(_) => {
                 return Err(de::Error::custom(
                     "'params' field, if present, must be object or array.",
-                ))
+                ));
             }
             None => false,
         };

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -87,10 +87,10 @@ pub struct EmptyStruct {}
 /// }
 /// # }
 /// ```
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, ToString)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
-#[derive(ToString)]
+#[strum(serialize_all = "snake_case")]
 pub enum CoreNotification {
     /// The 'edit' namespace, for view-specific editor actions.
     ///
@@ -368,10 +368,10 @@ pub struct FindQuery {
 ///
 /// Alongside the [`EditRequest`] members, these commands constitute
 /// the API for interacting with a particular window and document.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, ToString)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "method", content = "params")]
-#[derive(ToString)]
+#[strum(serialize_all = "snake_case")]
 pub enum EditNotification {
     Insert {
         chars: String,

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -124,7 +124,7 @@ pub struct CoreState {
     // for the time being we auto-start all plugins we find on launch.
     running_plugins: Vec<Plugin>,
     /// Stores the RPC subscriptions for plugins.
-    plugin_subscriptions: BTreeMap<String, Vec<PluginId>>,
+    plugin_subscriptions: RefCell<BTreeMap<String, Vec<PluginId>>>,
 }
 
 /// Initial setup and bookkeeping
@@ -185,7 +185,7 @@ impl CoreState {
             id_counter: Counter::default(),
             plugins: PluginCatalog::default(),
             running_plugins: Vec::new(),
-            plugin_subscriptions: BTreeMap::new(),
+            plugin_subscriptions: RefCell::new(BTreeMap::new()),
         }
     }
 
@@ -300,6 +300,7 @@ impl CoreState {
                 width_cache: &self.width_cache,
                 kill_ring: &self.kill_ring,
                 weak_core: self.self_ref.as_ref().unwrap(),
+                plugin_subscriptions: &self.plugin_subscriptions,
             }
         })
     }
@@ -316,7 +317,11 @@ impl CoreState {
         let cmd_json = json!(cmd);
         let method = cmd.to_string();
         match cmd {
-            Edit(crate::rpc::EditCommand { view_id, cmd }) => self.do_edit(view_id, cmd),
+            Edit(crate::rpc::EditCommand { view_id, cmd }) => {
+                let method = cmd.to_string();
+                self.do_edit(view_id, cmd);
+                self.handle_plugin_subscriptions(&method, &cmd_json);
+            }
             Save { view_id, file_path } => self.do_save(view_id, file_path),
             CloseView { view_id } => self.do_close_view(view_id),
             ModifyUserConfig { domain, changes } => self.do_modify_user_config(domain, changes),
@@ -354,12 +359,9 @@ impl CoreState {
     }
 
     fn do_edit(&mut self, view_id: ViewId, cmd: EditNotification) {
-        let cmd_json = json!(cmd);
-        let method = cmd.to_string();
         if let Some(mut edit_ctx) = self.make_context(view_id) {
             edit_ctx.do_edit(cmd);
         }
-        self.handle_plugin_subscriptions(&method, &cmd_json);
     }
 
     fn do_edit_sync(&mut self, view_id: ViewId, cmd: EditRequest) -> Result<Value, RemoteError> {
@@ -957,32 +959,11 @@ impl CoreState {
         }
     }
 
-    fn plugin_unsubscribe_all(&mut self, _plugin: PluginId) {
-        // todo: called when plugin exited
-    }
-
-    pub(crate) fn plugin_subscribe(&mut self, plugin: PluginId, rpc_method: &str) {
-        eprintln!("----s");
-//        self.plugin_subscriptions
-//            .entry(rpc_method.to_string())
-//            .or_insert(vec![plugin])
-//            .push(plugin);
-//        eprintln!("{:?}", self.plugin_subscriptions);
-    }
-
-    pub(crate) fn plugin_unsubscribe(&mut self, plugin: PluginId, rpc_method: &str) {
-        let key = rpc_method.to_string();
-        if let Some(entry) = self.plugin_subscriptions.get(rpc_method) {
-            self.plugin_subscriptions
-                .insert(key, entry.iter().cloned().filter(|&p| p != plugin).collect());
-        }
-    }
-
     pub(crate) fn handle_plugin_subscriptions(&self, method: &str, notification: &Value) {
-        if let Some(plugins) = self.plugin_subscriptions.get(method) {
+        if let Some(plugins) = self.plugin_subscriptions.borrow().get(method) {
             self.running_plugins.iter().for_each(|p| {
                 if plugins.contains(&p.id) {
-                    p.dispatch_core_notification(notification);
+                    p.dispatch_subscribed_notification(notification);
                 }
             });
         }

--- a/rust/plugin-lib/src/core_proxy.rs
+++ b/rust/plugin-lib/src/core_proxy.rs
@@ -62,6 +62,26 @@ impl CoreProxy {
         self.peer.send_rpc_notification("remove_status_item", &params)
     }
 
+    pub fn subscribe(&mut self, view_id: ViewId, rpc_method: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": view_id,
+            "rpc_method": rpc_method
+        });
+
+        self.peer.send_rpc_notification("subscribe", &params)
+    }
+
+    pub fn unsubscribe(&mut self, view_id: ViewId, rpc_method: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": view_id,
+            "rpc_method": rpc_method
+        });
+
+        self.peer.send_rpc_notification("unsubscribe", &params)
+    }
+
     pub fn display_hover(
         &mut self,
         view_id: ViewId,

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -111,10 +111,9 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         self.plugin.custom_command(v, method, params);
     }
 
-    fn do_subscribed_notification(&mut self, view_id: ViewId, notification: Value) {
-        let v = bail!(self.views.get_mut(&view_id), "subscribed_notification", self.pid, view_id);
+    fn do_subscribed_notification(&mut self, notification: Value) {
         let parsed_notification = serde_json::from_value(notification).expect("Could not parse subscribed notification");
-        self.plugin.subscribed_notification(v, parsed_notification);
+        self.plugin.subscribed_notification( parsed_notification);
     }
 
     fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
@@ -216,8 +215,8 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
             CustomCommand { view_id, method, params } => {
                 self.do_custom_command(view_id, &method, params)
             },
-            SubscribedNotification { view_id, notification } => {
-                self.do_subscribed_notification(view_id, notification);
+            SubscribedNotification { notification } => {
+                self.do_subscribed_notification( notification);
             }
             Ping(..) => (),
         }

--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -111,6 +111,12 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
         self.plugin.custom_command(v, method, params);
     }
 
+    fn do_subscribed_notification(&mut self, view_id: ViewId, notification: Value) {
+        let v = bail!(self.views.get_mut(&view_id), "subscribed_notification", self.pid, view_id);
+        let parsed_notification = serde_json::from_value(notification).expect("Could not parse subscribed notification");
+        self.plugin.subscribed_notification(v, parsed_notification);
+    }
+
     fn do_new_buffer(&mut self, ctx: &RpcCtx, buffers: Vec<PluginBufferInfo>) {
         let plugin_id = self.pid.unwrap();
         buffers
@@ -209,6 +215,9 @@ impl<'a, P: Plugin> RpcHandler for Dispatcher<'a, P> {
             LanguageChanged { view_id, new_lang } => self.do_language_changed(view_id, new_lang),
             CustomCommand { view_id, method, params } => {
                 self.do_custom_command(view_id, &method, params)
+            },
+            SubscribedNotification { view_id, notification } => {
+                self.do_subscribed_notification(view_id, notification);
             }
             Ping(..) => (),
         }

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -184,7 +184,7 @@ pub trait Plugin {
 
     /// Called with a subscribed core notification.
     #[allow(unused_variables)]
-    fn subscribed_notification(&mut self, view: &mut View<Self::Cache>, notification: CoreNotification) {}
+    fn subscribed_notification(&mut self, notification: CoreNotification) {}
 
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that

--- a/rust/plugin-lib/src/lib.rs
+++ b/rust/plugin-lib/src/lib.rs
@@ -40,10 +40,12 @@ use std::path::Path;
 
 use crate::xi_core::plugin_rpc::{GetDataResponse, TextUnit};
 use crate::xi_core::{ConfigTable, LanguageId};
+use crate::xi_core::rpc::CoreNotification;
 use serde_json::Value;
 use xi_rope::interval::IntervalBounds;
 use xi_rope::RopeDelta;
 use xi_rpc::{ReadError, RpcLoop};
+
 
 use self::dispatch::Dispatcher;
 
@@ -179,6 +181,10 @@ pub trait Plugin {
     /// Called with a custom command.
     #[allow(unused_variables)]
     fn custom_command(&mut self, view: &mut View<Self::Cache>, method: &str, params: Value) {}
+
+    /// Called with a subscribed core notification.
+    #[allow(unused_variables)]
+    fn subscribed_notification(&mut self, view: &mut View<Self::Cache>, notification: CoreNotification) {}
 
     /// Called when the runloop is idle, if the plugin has previously
     /// asked to be scheduled via `View::schedule_idle()`. Plugins that

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -227,6 +227,26 @@ impl<C: Cache> View<C> {
         });
         self.peer.send_rpc_notification("remove_status_item", &params);
     }
+
+    pub fn subscribe(&mut self, rpc_method: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "rpc_method": rpc_method
+        });
+
+        self.peer.send_rpc_notification("subscribe", &params)
+    }
+
+    pub fn unsubscribe(&mut self, rpc_method: &str) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "rpc_method": rpc_method
+        });
+
+        self.peer.send_rpc_notification("unsubscribe", &params)
+    }
 }
 
 /// A simple wrapper type that acts as a `DataSource`.


### PR DESCRIPTION
# Allow plugins to subscribe to core events

This is more of an exploratory PR. It would be nice if plugins could subscribe to events happening in the core, for example to changes of selections, movements, gestures, etc.

Plugins can subscribe to `CoreNotification` and `EditNotification` by using the snake case name of the notification:

```rust
impl Plugin for ExamplePlugin {
    type Cache = ChunkCache;

    fn new_view(&mut self, view: &mut View<Self::Cache>) {
        view.subscribe("insert");
        view.subscribe("click");
    }
}
```

Subscribed events can be processed in the plugin:

```rust
fn subscribed_notification(
        &mut self,
        notification: CoreNotification) {

    match notification {
        CoreNotification::Edit(_) => {},
        _ => {}
    }
}
```

I am not sure if it's a good idea to subscribe to `CoreNotification`s or if instead xi should send some custom events such as `SelectionChange`, ... since for example in the case of selections there are several `EditNotifications` that cause changes (`SelectAll`, `Drag`, `FindAll`, ...). 
I'd be happy to discuss better potential solutions.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
