### PR TITLE
Revert "Add interval method implementation for spans"

### DIFF
--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -107,10 +107,6 @@ impl<T: Clone> NodeInfo for SpansInfo<T> {
         }
         SpansInfo { n_spans: l.spans.len(), iv, phantom: PhantomData }
     }
-
-    fn interval(&self, _len: usize) -> Interval {
-        self.iv
-    }
 }
 
 pub struct SpansBuilder<T: Clone> {
@@ -338,8 +334,8 @@ impl<'a, T: Clone> Iterator for SpanIter<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
+
     fn test_merge() {
         // merging 1 1 1 1 1 1 1 1 1 16
         // with    2 2 4 4     8 8
@@ -431,22 +427,5 @@ mod tests {
         assert_eq!(*val, 9);
 
         assert!(merged_iter.next().is_none());
-    }
-
-    // Creates an interval tree and fills it with enough spans to guarantee it
-    // will contain more than one leaf node. The first interval overlaps all the
-    // other intervals. Tests that taking a slice from the end of the tree
-    // includes the interval that is stored at the beginning of the tree.
-    #[test]
-    fn test_overlapping_subseq() {
-        let mut builder = SpansBuilder::new(MAX_LEAF + 1);
-        builder.add_span(Interval::new(0, MAX_LEAF + 1), true);
-        for position in 0..MAX_LEAF {
-            builder.add_span(Interval::new(position, position + 1), false);
-        }
-        let spans = builder.build().subseq(MAX_LEAF..);
-        let mut iterator = spans.iter();
-        assert_eq!(iterator.next(), Some((Interval::new(0, 1), &true)));
-        assert_eq!(iterator.next(), None);
     }
 }


### PR DESCRIPTION
Reverts xi-editor/xi-editor#1122

So this change is causing span edits to break (#1130) and needs a bit more work.

Here's a test case that illustrates the current problem.

```rust
    #[test]
    fn edit_maintains_length_multi_node() {
        let size = MAX_LEAF + 1;
        let mut builder = SpansBuilder::new(size * 2);

        for i in 0..size {
            builder.add_span( i * 2..i * 2 + 2, i + 1);
        }
        let mut spans = builder.build();

        let mut builder = SpansBuilder::new(2);
        builder.add_span(.., 0);

        let pre_edit_spans = spans.clone();

        let edit = builder.build();
        spans.edit(1..3, edit);
        assert_eq!(pre_edit_spans.len(), spans.len());
    }
```

I dug into this a bit, and suspect the issue is with `SpansInfo::accumulate / SpansInfo::compute_info` but it's hard to be totally sure because of how everything fits together.


closes #1130 