### PR TITLE
Update improve memory efficiency of rope diffing

### DIFF
--- a/rust/rope/src/diff.rs
+++ b/rust/rope/src/diff.rs
@@ -14,8 +14,8 @@
 
 //! Computing deltas between two ropes.
 
-use std::collections::HashMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::ops::Range;
 
 use crate::compare::RopeScanner;
@@ -248,9 +248,13 @@ impl DiffBuilder {
 }
 
 /// Create a HashMap based on each line in the rope wich respect parameters
-/// given, a mininum line length and some threshold. This function always 
+/// given, a mininum line length and some threshold. This function always
 /// ignore whitespace at the begining of line.
-fn make_line_hashes<'a>(base: &'a Rope, min_size: usize, threshold: Range<usize>) -> HashMap<Cow<'a, str>, usize> {
+fn make_line_hashes<'a>(
+    base: &'a Rope,
+    min_size: usize,
+    threshold: Range<usize>,
+) -> HashMap<Cow<'a, str>, usize> {
     let mut offset = threshold.start;
     let mut line_hashes = HashMap::with_capacity(base.len() / 60);
     for line in base.lines_raw(threshold) {

--- a/rust/rope/src/diff.rs
+++ b/rust/rope/src/diff.rs
@@ -250,10 +250,10 @@ impl DiffBuilder {
 /// Create a HashMap based on each line in the rope wich respect parameters
 /// given, a mininum line length and some threshold. This function always 
 /// ignore whitespace at the begining of line.
-fn make_line_hashes<'a>(base: &'a Rope, min_size: usize, range: Range<usize>) -> HashMap<Cow<'a, str>, usize> {
-    let mut offset = range.start;
+fn make_line_hashes<'a>(base: &'a Rope, min_size: usize, threshold: Range<usize>) -> HashMap<Cow<'a, str>, usize> {
+    let mut offset = threshold.start;
     let mut line_hashes = HashMap::with_capacity(base.len() / 60);
-    for line in base.lines_raw(range.start..range.end) {
+    for line in base.lines_raw(threshold) {
         let non_ws = non_ws_offset(&line);
         if line.len() - non_ws >= min_size {
             let cow = match line {

--- a/rust/rope/src/diff.rs
+++ b/rust/rope/src/diff.rs
@@ -16,7 +16,6 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::Range;
 
 use crate::compare::RopeScanner;
 use crate::delta::{Delta, DeltaElement};
@@ -56,7 +55,6 @@ impl Diff<RopeInfo> for LineHashDiff {
         let mut scanner = RopeScanner::new(base, target);
         let (start_offset, diff_end) = scanner.find_min_diff_range();
         let target_end = target.len() - diff_end;
-        let base_end = base.len() - diff_end;
 
         if start_offset > 0 {
             builder.copy(0, 0, start_offset);
@@ -67,7 +65,7 @@ impl Diff<RopeInfo> for LineHashDiff {
             return builder.to_delta(base, target);
         }
 
-        let line_hashes = make_line_hashes(&base, MIN_SIZE, start_offset..base_end);
+        let line_hashes = make_line_hashes(&base, MIN_SIZE);
 
         let line_count = target.measure::<LinesMetric>() + 1;
         let mut matches = Vec::with_capacity(line_count);
@@ -247,17 +245,12 @@ impl DiffBuilder {
     }
 }
 
-/// Create a HashMap based on each line in the rope wich respect parameters
-/// given, a mininum line length and some threshold. This function always
-/// ignore whitespace at the begining of line.
-fn make_line_hashes<'a>(
-    base: &'a Rope,
-    min_size: usize,
-    threshold: Range<usize>,
-) -> HashMap<Cow<'a, str>, usize> {
-    let mut offset = threshold.start;
+/// Create a HashMap based on each line in the rope wich respect a mininum line length.
+/// This function always ignore whitespace at the begining of line.
+fn make_line_hashes<'a>(base: &'a Rope, min_size: usize) -> HashMap<Cow<'a, str>, usize> {
+    let mut offset = 0;
     let mut line_hashes = HashMap::with_capacity(base.len() / 60);
-    for line in base.lines_raw(threshold) {
+    for line in base.lines_raw(..) {
         let non_ws = non_ws_offset(&line);
         if line.len() - non_ws >= min_size {
             let cow = match line {

--- a/rust/rope/src/diff.rs
+++ b/rust/rope/src/diff.rs
@@ -245,8 +245,8 @@ impl DiffBuilder {
     }
 }
 
-/// Create a HashMap based on each line in the rope wich respect a mininum line length.
-/// This function always ignore whitespace at the begining of line.
+/// Creates a map of lines to offsets, ignoring trailing whitespace, and only for those lines
+/// where line.len() >= min_size. Offsets refer to the first non-whitespace byte in the line.
 fn make_line_hashes<'a>(base: &'a Rope, min_size: usize) -> HashMap<Cow<'a, str>, usize> {
     let mut offset = 0;
     let mut line_hashes = HashMap::with_capacity(base.len() / 60);

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -18,7 +18,8 @@
 use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::fmt;
-use std::ops::Add;
+use std::ops::{Add, Range};
+use std::hash::{Hash, Hasher};
 use std::str;
 use std::str::FromStr;
 use std::string::ParseError;
@@ -932,6 +933,47 @@ impl<'a> Iterator for Lines<'a> {
         }
     }
 }
+
+pub struct RopeSlice<'a> (
+    pub &'a Rope,
+    pub Range<usize>
+);
+
+impl<'a> std::fmt::Debug for RopeSlice<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        let temp = &String::from(self.0)[self.1.clone()];
+        f.debug_struct("RopeSlice")
+            .field("slice", &temp)
+            .finish()
+    }
+}
+
+impl<'a> Hash for RopeSlice<'a> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for self_chunk in self.0.iter_chunks(self.1.clone()) {
+            Hasher::write(state, self_chunk.as_bytes());
+        }
+        self.1.hash(state);
+    }
+}
+
+impl<'a> PartialEq for RopeSlice<'a> {
+    fn eq(&self, other: &RopeSlice) -> bool {
+        if (self.1.end - self.1.start) != (other.1.end - other.1.start) {
+            return false;
+        } else {
+            let iter = self.0.iter_chunks(self.1.clone()).zip(other.0.iter_chunks(other.1.clone()));
+            for (self_chunk, other_chunk) in iter {
+                if self_chunk != other_chunk {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}
+
+impl<'a> Eq for RopeSlice<'a> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

I implement the option proposed by Raph with a new RopeSlice struct to improve memory efficiency of rope diffing.

I keep an eye on performance and it's may be not what you want as you can see bellow.

**Benchmark before my commit:**
running 10 tests
test hash_diff      ... bench:       1,266 ns/iter (+/- 463)
test hash_diff_big  ... bench:     183,348 ns/iter (+/- 30,961)
test hash_diff_med  ... bench:      29,436 ns/iter (+/- 8,489)
test ne_idx_avx     ... bench:       5,297 ns/iter (+/- 834)
test ne_idx_detect  ... bench:       5,258 ns/iter (+/- 682)
test ne_idx_rev_sse ... bench:      13,240 ns/iter (+/- 2,105)
test ne_idx_rev_sw  ... bench:      68,948 ns/iter (+/- 6,669)
test ne_idx_sse     ... bench:       9,636 ns/iter (+/- 1,413)
test ne_idx_sw      ... bench:           0 ns/iter (+/- 0)
test scanner        ... bench:      11,012 ns/iter (+/- 4,030)

**Benchmark after my commit:**
running 10 tests
test hash_diff      ... bench:       1,127 ns/iter (+/- 332)
test hash_diff_big  ... bench:   6,765,850 ns/iter (+/- 317,297)
test hash_diff_med  ... bench:     192,641 ns/iter (+/- 44,295)
test ne_idx_avx     ... bench:       5,111 ns/iter (+/- 468)
test ne_idx_detect  ... bench:       4,988 ns/iter (+/- 477)
test ne_idx_rev_sse ... bench:      12,778 ns/iter (+/- 1,155)
test ne_idx_rev_sw  ... bench:      68,279 ns/iter (+/- 6,189)
test ne_idx_sse     ... bench:       6,288 ns/iter (+/- 3,110)
test ne_idx_sw      ... bench:           0 ns/iter (+/- 0)
test scanner        ... bench:      11,032 ns/iter (+/- 3,316)

The performance drop come from removing whitespace from my slice **(diff.rs line 91)** which make me create a new RopeSlice (or make my previous slice mutable).

I didn't manage to remove the overhead but I'm totally new to rust so I hope you have idea to solve it or I can try the second option proposed to improve the memory efficiency of rope diffing.

## Related Issues
`closes #946 `

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
