### PR TITLE
[WIP] Add behavior when xi-editor detects external changes on an edited file

### DIFF
--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -74,6 +74,15 @@ impl Client {
         self.0.send_rpc_notification("available_languages", &json!({ "languages": languages }))
     }
 
+    pub fn file_externally_changed(&self, view_id: ViewId) {
+        self.0.send_rpc_notification(
+            "file_externally_changed",
+            &json!({
+                "view_id": view_id,
+            }),
+        );
+    }
+
     pub fn theme_changed(&self, name: &str, theme: &ThemeSettings) {
         self.0.send_rpc_notification(
             "theme_changed",


### PR DESCRIPTION
## Summary

We send a 'content_changed' notification to the client

I guess that this will need more changes, but this is a first move to get feedback from the maintainers.

Is this the right direction?

## Related Issues

Closes #1126

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.

