### PR TITLE
Add DefaultMetric trait

### DIFF
--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -16,7 +16,7 @@
 //! storing the result of line breaking.
 
 use crate::interval::Interval;
-use crate::tree::{Leaf, Metric, Node, NodeInfo, TreeBuilder};
+use crate::tree::{DefaultMetric, Leaf, Metric, Node, NodeInfo, TreeBuilder};
 use std::cmp::min;
 use std::mem;
 
@@ -89,6 +89,10 @@ impl NodeInfo for BreaksInfo {
     fn compute_info(l: &BreaksLeaf) -> BreaksInfo {
         BreaksInfo(l.data.len())
     }
+}
+
+impl DefaultMetric for BreaksInfo {
+    type DefaultMetric = BreaksMetric;
 }
 
 impl BreaksLeaf {

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -25,7 +25,7 @@ use std::string::ParseError;
 
 use crate::delta::{Delta, DeltaElement};
 use crate::interval::{Interval, IntervalBounds};
-use crate::tree::{Cursor, Leaf, Metric, Node, NodeInfo, TreeBuilder};
+use crate::tree::{Cursor, DefaultMetric, Leaf, Metric, Node, NodeInfo, TreeBuilder};
 
 use bytecount;
 use memchr::{memchr, memrchr};
@@ -142,6 +142,10 @@ impl NodeInfo for RopeInfo {
     fn identity() -> Self {
         RopeInfo { lines: 0, utf16_size: 0 }
     }
+}
+
+impl DefaultMetric for RopeInfo {
+    type DefaultMetric = BaseMetric;
 }
 
 //TODO: document metrics, based on https://github.com/google/xi-editor/issues/456

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -424,7 +424,7 @@ impl<N: NodeInfo> Node<N> {
 }
 
 impl<N: DefaultMetric> Node<N> {
-    /// Measures the length of the text bounded by ``DefaultMetric::measure(m1)`` with another metric.
+    /// Measures the length of the text bounded by ``DefaultMetric::measure(offset)`` with another metric.
     ///
     /// # Examples
     /// ```

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -60,6 +60,15 @@ pub trait NodeInfo: Clone {
     }
 }
 
+/// A trait indicating the default metric of a NodeInfo.
+///
+/// Adds quality of life functions to
+/// Node\<N\>, where N is a DefaultMetric.
+/// For example, [Node\<DefaultMetric\>.count](struct.Node.html#method.count).
+pub trait DefaultMetric: NodeInfo {
+    type DefaultMetric: Metric<Self>;
+}
+
 /// A trait for the leaves of trees of type [Node](struct.Node.html).
 ///
 /// Two leafs can be concatenated using `push_maybe_split`.
@@ -411,6 +420,25 @@ impl<N: NodeInfo> Node<N> {
         let l = node.get_leaf();
         let base = M1::to_base_units(l, m1);
         m2 + M2::from_base_units(l, base)
+    }
+}
+
+impl<N: DefaultMetric> Node<N> {
+    /// Measures the length of the text bounded by ``DefaultMetric::measure(m1)`` with another metric.
+    ///
+    /// # Examples
+    /// ```
+    /// use crate::xi_rope::{Rope, LinesMetric};
+    ///
+    /// // the default metric of Rope is BaseMetric (aka number of bytes)
+    /// let my_rope = Rope::from("first line \n second line \n");
+    ///
+    /// // count the number of lines in my_rope
+    /// let num_lines = my_rope.count::<LinesMetric>(my_rope.len());
+    /// assert_eq!(2, num_lines);
+    /// ```
+    pub fn count<M: Metric<N>>(&self, offset: usize) -> usize {
+        self.convert_metrics::<N::DefaultMetric, M>(offset)
     }
 }
 


### PR DESCRIPTION
## Summary
Described in [Issue 1043](https://github.com/xi-editor/xi-editor/issues/1043#issue-391410173)

Essentially, it isn't clear why you must specify/keep track of the base metric for a rope type when calling `Node::convert_metrics`.

BaseMetric cannot be an associated type of NodeInfo because some Ropes do not have base Metrics, such as Spans.

However, we can create a trait DefaultMetric that implements NodeInfo. That way, any Rope<N> where N: DefaultMetric will have these ease of use functions.

It is not called BaseMetric because that name is already taken by Rope's base metric.

## Related Issues
closes #1043

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [X] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [X] I have updated comments / documentation related to the changes I made.
- [X] I have rebased my PR branch onto xi-editor/master.