### PR TITLE
Use DefaultMetric::count where applicable

### DIFF
--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -163,7 +163,7 @@ impl Lines {
     pub(crate) fn visual_line_of_offset(&self, text: &Rope, offset: usize) -> usize {
         let mut line = text.line_of_offset(offset);
         if self.wrap != WrapWidth::None {
-            line += self.breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(offset)
+            line += self.breaks.count::<BreaksMetric>(offset)
         }
         line
     }
@@ -309,8 +309,8 @@ impl Lines {
 
         // count the soft breaks in the region we will rewrap, before we update them.
         let inval_soft =
-            self.breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(old_logical_end_offset)
-                - self.breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(prev_break);
+            self.breaks.count::<BreaksMetric>(old_logical_end_offset)
+                - self.breaks.count::<BreaksMetric>(prev_break);
 
         // update soft breaks, adding empty spans in the edited region
         let mut builder = BreakBuilder::new();
@@ -416,8 +416,8 @@ impl Lines {
         let end = task.start + breaks.len();
 
         // this is correct *only* when an edit has not occured.
-        let inval_soft = self.breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(end)
-            - self.breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(task.start);
+        let inval_soft = self.breaks.count::<BreaksMetric>(end)
+            - self.breaks.count::<BreaksMetric>(task.start);
 
         let hard_count = 1 + text.line_of_offset(end) - text.line_of_offset(task.start);
 
@@ -772,8 +772,8 @@ impl<'a> MergedBreaks<'a> {
 }
 
 fn merged_line_of_offset(text: &Rope, soft: &Breaks, offset: usize) -> usize {
-    text.convert_metrics::<BaseMetric, LinesMetric>(offset)
-        + soft.convert_metrics::<BreaksBaseMetric, BreaksMetric>(offset)
+    text.count::<LinesMetric>(offset)
+        + soft.count::<BreaksMetric>(offset)
 }
 
 #[cfg(test)]

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -308,9 +308,8 @@ impl Lines {
         let next_hard_break = text.offset_of_line(new_logical_end_line);
 
         // count the soft breaks in the region we will rewrap, before we update them.
-        let inval_soft =
-            self.breaks.count::<BreaksMetric>(old_logical_end_offset)
-                - self.breaks.count::<BreaksMetric>(prev_break);
+        let inval_soft = self.breaks.count::<BreaksMetric>(old_logical_end_offset)
+            - self.breaks.count::<BreaksMetric>(prev_break);
 
         // update soft breaks, adding empty spans in the edited region
         let mut builder = BreakBuilder::new();
@@ -416,8 +415,8 @@ impl Lines {
         let end = task.start + breaks.len();
 
         // this is correct *only* when an edit has not occured.
-        let inval_soft = self.breaks.count::<BreaksMetric>(end)
-            - self.breaks.count::<BreaksMetric>(task.start);
+        let inval_soft =
+            self.breaks.count::<BreaksMetric>(end) - self.breaks.count::<BreaksMetric>(task.start);
 
         let hard_count = 1 + text.line_of_offset(end) - text.line_of_offset(task.start);
 
@@ -772,8 +771,7 @@ impl<'a> MergedBreaks<'a> {
 }
 
 fn merged_line_of_offset(text: &Rope, soft: &Breaks, offset: usize) -> usize {
-    text.count::<LinesMetric>(offset)
-        + soft.count::<BreaksMetric>(offset)
+    text.count::<LinesMetric>(offset) + soft.count::<BreaksMetric>(offset)
 }
 
 #[cfg(test)]

--- a/rust/core-lib/src/linewrap.rs
+++ b/rust/core-lib/src/linewrap.rs
@@ -17,8 +17,7 @@
 use std::cmp::Ordering;
 use std::ops::Range;
 
-use xi_rope::breaks::{BreakBuilder, Breaks, BreaksBaseMetric, BreaksInfo, BreaksMetric};
-use xi_rope::rope::BaseMetric;
+use xi_rope::breaks::{BreakBuilder, Breaks, BreaksInfo, BreaksMetric};
 use xi_rope::spans::Spans;
 use xi_rope::{Cursor, Interval, LinesMetric, Rope, RopeDelta, RopeInfo};
 use xi_trace::trace_block;

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -311,4 +311,19 @@ mod tests {
         let node = gen(100);
         assert_eq!(node.len(), 1000);
     }
+
+    #[test]
+    fn default_metric_test() {
+        use super::BreaksBaseMetric;
+
+        let breaks = gen(10);
+        assert_eq!(
+            breaks.convert_metrics::<BreaksBaseMetric, BreaksMetric>(5),
+            breaks.count::<BreaksMetric>(5)
+        );
+        assert_eq!(
+            breaks.convert_metrics::<BreaksMetric, BreaksBaseMetric>(7),
+            breaks.convert_to_base_units::<BreaksMetric>(7)
+        );
+    }
 }

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -323,7 +323,7 @@ mod tests {
         );
         assert_eq!(
             breaks.convert_metrics::<BreaksMetric, BreaksBaseMetric>(7),
-            breaks.convert_to_base_units::<BreaksMetric>(7)
+            breaks.count_base_units::<BreaksMetric>(7)
         );
     }
 }

--- a/rust/rope/src/breaks.rs
+++ b/rust/rope/src/breaks.rs
@@ -92,7 +92,7 @@ impl NodeInfo for BreaksInfo {
 }
 
 impl DefaultMetric for BreaksInfo {
-    type DefaultMetric = BreaksMetric;
+    type DefaultMetric = BreaksBaseMetric;
 }
 
 impl BreaksLeaf {

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -1267,8 +1267,7 @@ mod tests {
         let utf16_units = rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 11);
 
-        let utf8_offset =
-            rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
+        let utf8_offset = rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 13);
 
         //for next line
@@ -1276,8 +1275,7 @@ mod tests {
         let utf16_units = rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 17);
 
-        let utf8_offset =
-            rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
+        let utf8_offset = rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 19);
     }
 

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -570,7 +570,7 @@ impl Rope {
     /// This function will panic if `offset > self.len()`. Callers are expected to
     /// validate their input.
     pub fn line_of_offset(&self, offset: usize) -> usize {
-        self.convert_metrics::<BaseMetric, LinesMetric>(offset)
+        self.count::<LinesMetric>(offset)
     }
 
     /// Return the byte offset corresponding to the line number `line`.
@@ -1238,7 +1238,7 @@ mod tests {
 
         // position after 'f' in four
         let utf8_offset = 9;
-        let utf16_units = rope.convert_metrics::<BaseMetric, Utf16CodeUnitsMetric>(utf8_offset);
+        let utf16_units = rope.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 9);
 
         let utf8_offset = rope.convert_metrics::<Utf16CodeUnitsMetric, BaseMetric>(utf16_units);
@@ -1252,7 +1252,7 @@ mod tests {
         // position after 'f' in four
         let utf8_offset = 13;
         let utf16_units =
-            rope_with_emoji.convert_metrics::<BaseMetric, Utf16CodeUnitsMetric>(utf8_offset);
+            rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 11);
 
         let utf8_offset =
@@ -1262,7 +1262,7 @@ mod tests {
         //for next line
         let utf8_offset = 19;
         let utf16_units =
-            rope_with_emoji.convert_metrics::<BaseMetric, Utf16CodeUnitsMetric>(utf8_offset);
+            rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 17);
 
         let utf8_offset =

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -593,7 +593,7 @@ impl Rope {
         } else if line == max_line {
             return self.len();
         }
-        self.convert_to_base_units::<LinesMetric>(line)
+        self.count_base_units::<LinesMetric>(line)
     }
 
     /// Returns an iterator over chunks of the rope.
@@ -1225,7 +1225,7 @@ mod tests {
         );
         assert_eq!(
             rope.convert_metrics::<LinesMetric, BaseMetric>(2),
-            rope.convert_to_base_units::<LinesMetric>(2)
+            rope.count_base_units::<LinesMetric>(2)
         );
     }
 
@@ -1254,7 +1254,7 @@ mod tests {
         let utf16_units = rope.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 9);
 
-        let utf8_offset = rope.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
+        let utf8_offset = rope.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 9);
 
         let rope_with_emoji = Rope::from("hi\ni'm\n😀 four\nlines");
@@ -1268,7 +1268,7 @@ mod tests {
         assert_eq!(utf16_units, 11);
 
         let utf8_offset =
-            rope_with_emoji.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
+            rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 13);
 
         //for next line
@@ -1277,7 +1277,7 @@ mod tests {
         assert_eq!(utf16_units, 17);
 
         let utf8_offset =
-            rope_with_emoji.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
+            rope_with_emoji.count_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 19);
     }
 

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -1217,6 +1217,19 @@ mod tests {
     }
 
     #[test]
+    fn default_metric_test() {
+        let rope = Rope::from("hi\ni'm\nfour\nlines\n");
+        assert_eq!(
+            rope.convert_metrics::<BaseMetric, LinesMetric>(rope.len()),
+            rope.count::<LinesMetric>(rope.len())
+        );
+        assert_eq!(
+            rope.convert_metrics::<LinesMetric, BaseMetric>(2),
+            rope.convert_to_base_units::<LinesMetric>(2)
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn line_of_offset_panic() {
         let rope = Rope::from("hi\ni'm\nfour\nlines");

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -593,7 +593,7 @@ impl Rope {
         } else if line == max_line {
             return self.len();
         }
-        self.convert_metrics::<LinesMetric, BaseMetric>(line)
+        self.convert_to_base_units::<LinesMetric>(line)
     }
 
     /// Returns an iterator over chunks of the rope.
@@ -1241,7 +1241,7 @@ mod tests {
         let utf16_units = rope.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 9);
 
-        let utf8_offset = rope.convert_metrics::<Utf16CodeUnitsMetric, BaseMetric>(utf16_units);
+        let utf8_offset = rope.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 9);
 
         let rope_with_emoji = Rope::from("hi\ni'm\n😀 four\nlines");
@@ -1255,7 +1255,7 @@ mod tests {
         assert_eq!(utf16_units, 11);
 
         let utf8_offset =
-            rope_with_emoji.convert_metrics::<Utf16CodeUnitsMetric, BaseMetric>(utf16_units);
+            rope_with_emoji.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 13);
 
         //for next line
@@ -1264,7 +1264,7 @@ mod tests {
         assert_eq!(utf16_units, 17);
 
         let utf8_offset =
-            rope_with_emoji.convert_metrics::<Utf16CodeUnitsMetric, BaseMetric>(utf16_units);
+            rope_with_emoji.convert_to_base_units::<Utf16CodeUnitsMetric>(utf16_units);
         assert_eq!(utf8_offset, 19);
     }
 

--- a/rust/rope/src/rope.rs
+++ b/rust/rope/src/rope.rs
@@ -1251,8 +1251,7 @@ mod tests {
 
         // position after 'f' in four
         let utf8_offset = 13;
-        let utf16_units =
-            rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
+        let utf16_units = rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 11);
 
         let utf8_offset =
@@ -1261,8 +1260,7 @@ mod tests {
 
         //for next line
         let utf8_offset = 19;
-        let utf16_units =
-            rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
+        let utf16_units = rope_with_emoji.count::<Utf16CodeUnitsMetric>(utf8_offset);
         assert_eq!(utf16_units, 17);
 
         let utf8_offset =

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -451,10 +451,10 @@ impl<N: DefaultMetric> Node<N> {
     /// let my_rope = Rope::from("first line \n second line \n");
     ///
     /// // get the byte offset of the line at index 1
-    /// let byte_offset = my_rope.convert_to_base_units::<LinesMetric>(1);
+    /// let byte_offset = my_rope.count_base_units::<LinesMetric>(1);
     /// assert_eq!(12, byte_offset);
     /// ```
-    pub fn convert_to_base_units<M: Metric<N>>(&self, offset: usize) -> usize {
+    pub fn count_base_units<M: Metric<N>>(&self, offset: usize) -> usize {
         self.convert_metrics::<M, N::DefaultMetric>(offset)
     }
 }

--- a/rust/rope/src/tree.rs
+++ b/rust/rope/src/tree.rs
@@ -440,6 +440,23 @@ impl<N: DefaultMetric> Node<N> {
     pub fn count<M: Metric<N>>(&self, offset: usize) -> usize {
         self.convert_metrics::<N::DefaultMetric, M>(offset)
     }
+
+    /// Measures the length of the text bounded by ``M::measure(offset)`` with the default metric.
+    ///
+    /// # Examples
+    /// ```
+    /// use crate::xi_rope::{Rope, LinesMetric};
+    ///
+    /// // the default metric of Rope is BaseMetric (aka number of bytes)
+    /// let my_rope = Rope::from("first line \n second line \n");
+    ///
+    /// // get the byte offset of the line at index 1
+    /// let byte_offset = my_rope.convert_to_base_units::<LinesMetric>(1);
+    /// assert_eq!(12, byte_offset);
+    /// ```
+    pub fn convert_to_base_units<M: Metric<N>>(&self, offset: usize) -> usize {
+        self.convert_metrics::<M, N::DefaultMetric>(offset)
+    }
 }
 
 impl<N: NodeInfo> Default for Node<N> {


### PR DESCRIPTION
## Summary
Change the default metric of Breaks from `BreaksMetric` to `BreaksBaseMetric`.

Replaces `Node<N>::convert_metrics` with `Node<DM>::count` where applicable. 

## Related Issues
Related to #1141 

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [X] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [X] I have updated comments / documentation related to the changes I made.
- [X] I have rebased my PR branch onto xi-editor/master.
