### PR TITLE
rope::find takes Option<&Regex> not &Option<Regex>

### DIFF
--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -270,9 +270,13 @@ impl Find {
 
         let mut raw_lines = text.lines_raw(from..to);
 
-        while let Some(start) =
-            find(&mut find_cursor, &mut raw_lines, self.case_matching, &search_string, &self.regex)
-        {
+        while let Some(start) = find(
+            &mut find_cursor,
+            &mut raw_lines,
+            self.case_matching,
+            &search_string,
+            self.regex.as_ref(),
+        ) {
             let end = find_cursor.pos();
 
             if self.whole_words && !self.is_matching_whole_words(text, start, end) {

--- a/rust/rope/src/find.rs
+++ b/rust/rope/src/find.rs
@@ -68,7 +68,7 @@ pub fn find(
     lines: &mut LinesRaw,
     cm: CaseMatching,
     pat: &str,
-    regex: &Option<Regex>,
+    regex: Option<&Regex>,
 ) -> Option<usize> {
     match find_progress(cursor, lines, cm, pat, usize::max_value(), regex) {
         FindResult::Found(start) => Some(start),
@@ -94,7 +94,7 @@ pub fn find_progress(
     cm: CaseMatching,
     pat: &str,
     num_steps: usize,
-    regex: &Option<Regex>,
+    regex: Option<&Regex>,
 ) -> FindResult {
     // empty search string
     if pat.is_empty() {
@@ -349,21 +349,21 @@ mod tests {
         let a = Rope::from("Löwe 老虎 Léopard");
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(..);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(0));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(13));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &None), Some(13));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", None), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", None), None);
         c.set(0);
         // Note: these two characters both start with 0xE8 in utf-8
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &None), Some(6));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", None), Some(6));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", &None), Some(9));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", None), Some(9));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", None), None);
     }
 
     #[test]
@@ -376,20 +376,20 @@ mod tests {
         let a = Rope::from(&s);
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(4000));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), Some(4013));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), Some(4000));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), Some(4013));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &None), Some(4013));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", None), Some(4013));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &None), Some(4006));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", None), Some(4006));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", &None), Some(4009));
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", None), Some(4009));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "虎", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", None), None);
     }
 
     #[test]
@@ -397,20 +397,20 @@ mod tests {
         let a = Rope::from("Löwe 老虎 Léopard");
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), Some(0));
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), Some(13));
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", None), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "l", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "léopard", &None), Some(13));
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "léopard", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "léopard", None), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "léopard", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "LÉOPARD", &None), Some(13));
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "LÉOPARD", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "LÉOPARD", None), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "LÉOPARD", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &None), Some(6));
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", None), Some(6));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", None), None);
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", &None), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", None), None);
     }
 
     #[test]
@@ -418,9 +418,9 @@ mod tests {
         let a = Rope::from("![cfg(test)]");
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(test)", &None), Some(5));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(test)", None), Some(5));
         c.set(0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(TEST)", &None), Some(5));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "(TEST)", None), Some(5));
     }
 
     #[test]
@@ -428,19 +428,19 @@ mod tests {
         let a = Rope::from("İ");
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i̇", &None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i̇", None), Some(0));
 
         let a = Rope::from("i̇");
         let mut c = Cursor::new(&a, 0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "İ", &None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "İ", None), Some(0));
 
         let a = Rope::from("\u{212A}");
         let mut c = Cursor::new(&a, 0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "k", &None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "k", None), Some(0));
 
         let a = Rope::from("k");
         let mut c = Cursor::new(&a, 0);
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\u{212A}", &None), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\u{212A}", None), Some(0));
     }
 
     #[test]
@@ -448,7 +448,7 @@ mod tests {
         let a = Rope::from("\u{0100}I");
         let mut c = Cursor::new(&a, 0);
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i", &None), Some(2));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "i", None), Some(2));
     }
 
     #[test]
@@ -458,11 +458,11 @@ mod tests {
         let mut raw_lines = a.lines_raw(0..a.len());
         let regex =
             RegexBuilder::new("L").size_limit(REGEX_SIZE_LIMIT).case_insensitive(true).build().ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(0));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(13));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(29));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(29));
         c.set(0);
         let regex = RegexBuilder::new("Léopard")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -470,9 +470,12 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), Some(13));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", regex.as_ref()),
+            Some(13)
+        );
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", regex.as_ref()), None);
         c.set(0);
         let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("老虎")
@@ -480,9 +483,12 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), Some(6));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", regex.as_ref()),
+            Some(6)
+        );
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -490,19 +496,19 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", regex.as_ref()), None);
         c.set(0);
         let regex =
             RegexBuilder::new(".").size_limit(REGEX_SIZE_LIMIT).case_insensitive(true).build().ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", &regex), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", regex.as_ref()), Some(0));
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", &regex), Some(5));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", regex.as_ref()), Some(5));
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -510,7 +516,7 @@ mod tests {
             .build()
             .ok();
         assert_eq!(
-            find(&mut c, &mut raw_lines, CaseInsensitive, "\\sLéopard\n.*", &regex),
+            find(&mut c, &mut raw_lines, CaseInsensitive, "\\sLéopard\n.*", regex.as_ref()),
             Some(12)
         );
     }
@@ -525,11 +531,11 @@ mod tests {
             .case_insensitive(false)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", regex.as_ref()), Some(0));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", regex.as_ref()), Some(13));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "L", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("Léopard")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -537,9 +543,9 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &regex), Some(13));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", regex.as_ref()), Some(13));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Léopard", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("老虎")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -547,9 +553,9 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &regex), Some(6));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", regex.as_ref()), Some(6));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "老虎", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -557,7 +563,7 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "Tiger", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new(".")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -565,21 +571,24 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, ".", &regex), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, ".", regex.as_ref()), Some(0));
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(false)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "\\s", &regex), Some(5));
+        assert_eq!(find(&mut c, &mut raw_lines, Exact, "\\s", regex.as_ref()), Some(5));
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(false)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, Exact, "\\sLéopard\n.*", &regex), Some(12));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, Exact, "\\sLéopard\n.*", regex.as_ref()),
+            Some(12)
+        );
     }
 
     #[test]
@@ -594,11 +603,11 @@ mod tests {
         let mut raw_lines = a.lines_raw(0..a.len());
         let regex =
             RegexBuilder::new("L").size_limit(REGEX_SIZE_LIMIT).case_insensitive(true).build().ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4000));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(4000));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4013));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(4013));
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", &regex), Some(4029));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "L", regex.as_ref()), Some(4029));
         c.set(0);
         let mut raw_lines = a.lines_raw(0..a.len());
         let regex = RegexBuilder::new("Léopard")
@@ -606,9 +615,12 @@ mod tests {
             .case_insensitive(true)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), Some(4013));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", regex.as_ref()),
+            Some(4013)
+        );
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Léopard", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("老虎")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -616,9 +628,12 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), Some(4006));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", regex.as_ref()),
+            Some(4006)
+        );
         raw_lines = a.lines_raw(c.pos()..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "老虎", regex.as_ref()), None);
         c.set(0);
         let regex = RegexBuilder::new("Tiger")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -626,19 +641,22 @@ mod tests {
             .build()
             .ok();
         let mut raw_lines = a.lines_raw(0..a.len());
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", &regex), None);
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "Tiger", regex.as_ref()), None);
         c.set(0);
         let mut raw_lines = a.lines_raw(0..a.len());
         let regex =
             RegexBuilder::new(".").size_limit(REGEX_SIZE_LIMIT).case_insensitive(true).build().ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", &regex), Some(0));
+        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, ".", regex.as_ref()), Some(0));
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\s")
             .size_limit(REGEX_SIZE_LIMIT)
             .case_insensitive(true)
             .build()
             .ok();
-        assert_eq!(find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", &regex), Some(4005));
+        assert_eq!(
+            find(&mut c, &mut raw_lines, CaseInsensitive, "\\s", regex.as_ref()),
+            Some(4005)
+        );
         raw_lines = a.lines_raw(c.pos()..a.len());
         let regex = RegexBuilder::new("\\sLéopard\n.*")
             .size_limit(REGEX_SIZE_LIMIT)
@@ -646,7 +664,7 @@ mod tests {
             .build()
             .ok();
         assert_eq!(
-            find(&mut c, &mut raw_lines, CaseInsensitive, "\\sLéopard\n.*", &regex),
+            find(&mut c, &mut raw_lines, CaseInsensitive, "\\sLéopard\n.*", regex.as_ref()),
             Some(4012)
         );
     }


### PR DESCRIPTION
closes #1146

This would be a semvar bump if we did regular releases, but we don't so 😁

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
