### PR TITLE
Deprecate AddSelectionAbove/Below

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Lê Viết Hoàng Dũng
 Markus Ast
 Raph Levien
 Hilmar Gústafsson
+Nicolai Søborg

--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -209,8 +209,8 @@ yank
 transpose
 select_all
 collapse_selections
-add_selection_above
-add_selection_below
+add_caret_above
+add_caret_below
 ```
 
 #### Transformations

--- a/rust/core-lib/src/edit_types.rs
+++ b/rust/core-lib/src/edit_types.rs
@@ -32,8 +32,10 @@ pub(crate) enum ViewEvent {
     ModifySelection(Movement),
     SelectAll,
     Scroll(LineRange),
-    AddSelectionAbove,
-    AddSelectionBelow,
+    AddCaretAbove,
+    AddCaretBelow,
+    AddSelectionAbove, // deprecated, use AddCaretAbove
+    AddSelectionBelow, // deprecated, use AddCaretBelow
     Click(MouseAction),
     Drag(MouseAction),
     Gesture { line: u64, col: u64, ty: GestureType },
@@ -214,6 +216,8 @@ impl From<EditNotification> for EventDomain {
             PageDownAndModifySelection =>
                 ViewEvent::ModifySelection(Movement::DownPage).into(),
             SelectAll => ViewEvent::SelectAll.into(),
+            AddCaretAbove => ViewEvent::AddCaretAbove.into(),
+            AddCaretBelow => ViewEvent::AddCaretBelow.into(),
             AddSelectionAbove => ViewEvent::AddSelectionAbove.into(),
             AddSelectionBelow => ViewEvent::AddSelectionBelow.into(),
             Scroll(range) => ViewEvent::Scroll(range).into(),

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -904,7 +904,7 @@ mod tests {
         lines.|]" );
 
         ctx.do_edit(EditNotification::CollapseSelections);
-        ctx.do_edit(EditNotification::AddSelectionAbove);
+        ctx.do_edit(EditNotification::AddCaretAbove);
         assert_eq!(harness.debug_render(),"\
         this is a string\n\
         that h|as three\n\
@@ -1775,7 +1775,7 @@ mod tests {
         Done.";
         ctx.do_edit(EditNotification::Insert { chars: multi_text.into() });
         ctx.do_edit(EditNotification::Gesture { line: 1, col: 9, ty: PointSelect });
-        ctx.do_edit(EditNotification::AddSelectionAbove);
+        ctx.do_edit(EditNotification::AddCaretAbove);
         ctx.do_edit(EditNotification::IncreaseNumber);
         assert_eq!(harness.debug_render(), "\
         example 43| number\n\
@@ -1833,7 +1833,7 @@ mod tests {
         ctx.do_edit(EditNotification::ToggleRecording { recording_name: Some(recording_name.clone()) });
 
         // Swap last word of the current line and the line below
-        ctx.do_edit(EditNotification::AddSelectionBelow);
+        ctx.do_edit(EditNotification::AddCaretBelow);
         ctx.do_edit(EditNotification::MoveToRightEndOfLine);
         ctx.do_edit(EditNotification::MoveWordLeftAndModifySelection);
         ctx.do_edit(EditNotification::Transpose);
@@ -1895,7 +1895,7 @@ mod tests {
         let harness = ContextHarness::new(initial_text);
         let mut ctx = harness.make_context();
         ctx.do_edit(EditNotification::Gesture { line: 1, col: 5, ty: PointSelect });
-        ctx.do_edit(EditNotification::AddSelectionAbove);
+        ctx.do_edit(EditNotification::AddCaretAbove);
         assert_eq!(harness.debug_render(),"\
         this |is a string\n\
         that |has three\n\
@@ -1905,7 +1905,7 @@ mod tests {
 
         ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::Gesture { line: 1, col: 5, ty: PointSelect });
-        ctx.do_edit(EditNotification::AddSelectionBelow);
+        ctx.do_edit(EditNotification::AddCaretBelow);
         assert_eq!(harness.debug_render(),"\
         this is a string\n\
         that |has three\n\
@@ -1915,7 +1915,7 @@ mod tests {
 
         ctx.do_edit(EditNotification::CollapseSelections);
         ctx.do_edit(EditNotification::Gesture { line: 4, col: 10, ty: PointSelect });
-        ctx.do_edit(EditNotification::AddSelectionAbove);
+        ctx.do_edit(EditNotification::AddCaretAbove);
         assert_eq!(harness.debug_render(),"\
         this is a string\n\
         that has t|hree\n\
@@ -1974,7 +1974,7 @@ mod tests {
         let mut ctx = harness.make_context();
 
         ctx.do_edit(EditNotification::Gesture{line: 0, col: 4, ty: PointSelect}); // end of first line
-        ctx.do_edit(EditNotification::AddSelectionBelow); // add cursor below that, at eof
+        ctx.do_edit(EditNotification::AddCaretBelow); // add cursor below that, at eof
         ctx.do_edit(EditNotification::Transpose);
 
         assert_eq!(harness.debug_render(), "wor\nd|");

--- a/rust/core-lib/src/rpc.rs
+++ b/rust/core-lib/src/rpc.rs
@@ -435,8 +435,10 @@ pub enum EditNotification {
     ScrollPageDown,
     PageDownAndModifySelection,
     SelectAll,
-    AddSelectionAbove,
-    AddSelectionBelow,
+    AddCaretAbove,
+    AddCaretBelow,
+    AddSelectionAbove, // deprecated, use AddCaretAbove
+    AddSelectionBelow, // deprecated, use AddCaretBelow
     Scroll(LineRange),
     Resize(Size),
     GotoLine {

--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -238,8 +238,10 @@ impl View {
             ModifySelection(movement) => self.do_move(text, movement, true),
             SelectAll => self.select_all(text),
             Scroll(range) => self.set_scroll(range.first, range.last),
-            AddSelectionAbove => self.add_selection_by_movement(text, Movement::UpExactPosition),
-            AddSelectionBelow => self.add_selection_by_movement(text, Movement::DownExactPosition),
+            AddCaretAbove => self.add_caret_by_movement(text, Movement::UpExactPosition),
+            AddSelectionAbove => self.add_caret_by_movement(text, Movement::UpExactPosition),
+            AddCaretBelow => self.add_caret_by_movement(text, Movement::DownExactPosition),
+            AddSelectionBelow => self.add_caret_by_movement(text, Movement::DownExactPosition),
             Gesture { line, col, ty } => self.do_gesture(text, line, col, ty),
             GotoLine { line } => self.goto_line(text, line),
             Find { chars, case_sensitive, regex, whole_words } => {
@@ -406,7 +408,7 @@ impl View {
         self.lc_shadow.partial_invalidate(first_line, last_line, invalid);
     }
 
-    fn add_selection_by_movement(&mut self, text: &Rope, movement: Movement) {
+    fn add_caret_by_movement(&mut self, text: &Rope, movement: Movement) {
         let mut sel = Selection::new();
         for &region in self.sel_regions() {
             sel.add_region(region);

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -253,8 +253,8 @@ const MOVEMENT_RPCS: &str = r#"{"method":"edit","params":{"view_id":"view-id-1",
 {"method":"edit","params":{"view_id":"view-id-1","method":"page_up_and_modify_selection","params":[]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"page_down_and_modify_selection","params":[]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"select_all","params":[]}}
-{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_above","params":[]}}
-{"method":"edit","params":{"view_id":"view-id-1","method":"add_selection_below","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"add_caret_above","params":[]}}
+{"method":"edit","params":{"view_id":"view-id-1","method":"add_caret_below","params":[]}}
 {"method":"edit","params":{"view_id":"view-id-1","method":"collapse_selections","params":[]}}"#;
 
 const TEXT_EDIT_RPCS: &str =


### PR DESCRIPTION
Implement idea from issue 1139

Maybe we want to extend this even further by adding an annotation with type `caret` (and change a bit it the codebase to differentiate between carets and selections).

- [X] I have responded to reviews and made changes where appropriate.
- [X] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [X] I have updated comments / documentation related to the changes I made.
- [X] I have rebased my PR branch onto xi-editor/master.
