### PR TITLE
Ignore comments when calculating indentation status

### DIFF
--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -449,7 +449,18 @@ impl<'a> PluginState {
         let metadata =
             self.get_metadata(view, syntax_set, prev_line).ok_or_else(|| Error::PeerDisconnect)?;
         let line = view.get_line(prev_line)?;
-        Ok(metadata.increase_indent(line))
+
+        let comment_str = match metadata.line_comment().map(|s| s.to_owned()) {
+            Some(s) => s,
+            None => return Ok(metadata.increase_indent(line)),
+        };
+
+        // if the previous line is a comment, the indent level should not be increased
+        if line.trim().starts_with(&comment_str.trim()) {
+            Ok(false)
+        } else {
+            Ok(metadata.increase_indent(line))
+        }
     }
 
     /// Test whether the indent level for this line should be decreased, by


### PR DESCRIPTION
## Summary
Ignore comment blocks when calculating indentation status. 

Before:
```Rust
1;
// fn foo() {
    2;
```

Now:
```Rust
1;
// fn foo() {
2;
```

Handles both `// fn foo() {` and `//fn foo() {` cases.

## Related Issues
#1003

## Checklist
- [x] Do not increase indent level by comments

## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.