### PR TITLE
add save_traces utility function

### DIFF
--- a/rust/trace/src/chrome_trace_dump.rs
+++ b/rust/trace/src/chrome_trace_dump.rs
@@ -25,14 +25,37 @@ extern crate test;
 
 use super::Sample;
 use serde_json;
-use std::fs::File;
-use std::io::{Error as IOError, Read, Write};
+use std::io::{Error as IOError, ErrorKind as IOErrorKind, Read, Write};
 
 #[derive(Debug)]
 pub enum Error {
     Io(IOError),
     Json(serde_json::Error),
     DecodingFormat(String),
+}
+
+impl From<IOError> for Error {
+    fn from(e: IOError) -> Error {
+        Error::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Error {
+        Error::Json(e)
+    }
+}
+
+impl From<String> for Error {
+    fn from(e: String) -> Error {
+        Error::DecodingFormat(e)
+    }
+}
+
+impl Error {
+    pub fn already_exists() -> Error {
+        Error::Io(IOError::from(IOErrorKind::AlreadyExists))
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -80,42 +103,6 @@ where
     R: Read,
 {
     serde_json::from_reader(input).map_err(Error::Json)
-}
-
-/// Save tracing data to path pointed to by the environment variable TRACE_OUTPUT, using the Trace
-/// Viewer format. Save path defaults to `./target/trace_output.trace`. Trace file can be opened
-/// with the Chrome browser by visiting the URL `about:tracing`. If `sorted_chronologically` is true
-/// then sort output traces chronologically by time of creation.
-pub fn save_traces(sorted_chronologically: bool) {
-    use std::env;
-
-    let traces = if sorted_chronologically {
-        super::samples_cloned_sorted()
-    } else {
-        super::samples_cloned_unsorted()
-    };
-
-    let trace_output_path = match env::var("TRACE_OUTPUT") {
-        Ok(output_path) => output_path,
-        Err(_) => {
-            println!("Environment variable TRACE_OUTPUT not set, defaulting to ./target/trace_output.trace");
-            String::from("./target/trace_output.trace")
-        }
-    };
-
-    let mut trace_file = match File::create(&trace_output_path) {
-        Ok(f) => f,
-        Err(_) => {
-            println!("Could not create trace output file at: {}.", &trace_output_path);
-            return;
-        }
-    };
-
-    if serialize(&traces, &mut trace_file).is_err() {
-        println!("Could not save trace file at: {}.", &trace_output_path);
-    } else {
-        println!("Saved trace file at: {}", &trace_output_path);
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Add a `save_traces` utility function, which saves trace output to a file which can be opened by Chrome's Trace Viewer. Location of output is determined by environment variable `TRACE_OUTPUT`.

## Related Issues
Currently trying to figure out where this function should go in druid-shell: https://github.com/xi-editor/druid/pull/35

Wondering if perhaps it should be a xi_trace utility?

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
