### PR TITLE
fix warnings in core-lib/src/files.rs

### DIFF
--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt;
-use std::fs::{self, File, Permissions};
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::str;
@@ -33,7 +33,7 @@ use crate::tabs::OPEN_FILE_EVENT_TOKEN;
 #[cfg(feature = "notify")]
 use crate::watcher::FileWatcher;
 #[cfg(target_family = "unix")]
-use std::os::unix::fs::PermissionsExt;
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 const UTF8_BOM: &str = "\u{feff}";
 
@@ -198,6 +198,7 @@ where
     Ok((rope, info))
 }
 
+#[allow(unused)]
 fn try_save(
     path: &Path,
     text: &Rope,
@@ -226,12 +227,11 @@ fn try_save(
 
     fs::rename(tmp_path, path)?;
 
-    if let Some(info_unwrapped) = file_info {
-        #[cfg(target_family = "unix")]
-        fs::set_permissions(
-            path,
-            Permissions::from_mode(info_unwrapped.permissions.unwrap_or(0o644)),
-        )?;
+    #[cfg(target_family = "unix")]
+    {
+        if let Some(info) = file_info {
+            fs::set_permissions(path, Permissions::from_mode(info.permissions.unwrap_or(0o644)))?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
Fix the following warnings in core-lib/src/files.rs:

```
warning: unused import: `Permissions`
  --> core-lib\src\file.rs:20:27
   |
20 | use std::fs::{self, File, Permissions};
   |                           ^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default

warning: unused import: `Permissions`
  --> core-lib\src\file.rs:20:27
   |
20 | use std::fs::{self, File, Permissions};
   |                           ^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default

warning: unused variable: `info_unwrapped`
   --> core-lib\src\file.rs:229:17
    |
229 |     if let Some(info_unwrapped) = file_info {
    |                 ^^^^^^^^^^^^^^ help: consider using `_info_unwrapped` instead
    |
    = note: #[warn(unused_variables)] on by default

warning: unused variable: `info_unwrapped`
   --> core-lib\src\file.rs:229:17
    |
229 |     if let Some(info_unwrapped) = file_info {
    |                 ^^^^^^^^^^^^^^ help: consider using `_info_unwrapped` instead
    |
    = note: #[warn(unused_variables)] on by default
```

## Related Issues
None applicable.

## Review Checklist
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
