### PR TITLE
Implement method to delete spans intersecting with interval

### DIFF
--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -301,10 +301,10 @@ impl<T: Clone> Spans<T> {
         *self = b.build();
     }
 
-    /// FIXME: Instead of iterating through all spans every time, another option would be to go
-    /// leaf-by-leaf, and check each leaf for whether or not it has any items in the interval;
-    /// if they don't we keep them unchanged, otherwise we do this operation, but only within the leaf.
-    ///
+    // FIXME: Instead of iterating through all spans every time, another option would be to go
+    // leaf-by-leaf, and check each leaf for whether or not it has any items in the interval;
+    // if they don't we keep them unchanged, otherwise we do this operation, but only within the leaf.
+    //
     /// Deletes all spans that intersect with `interval`.
     pub fn delete_intersecting(&mut self, interval: Interval) {
         let mut builder = SpansBuilder::new(self.len());


### PR DESCRIPTION
This adds the method `invalidate_intersecting` to `Spans` which deletes all spans that are intersecting with a provided interval. 

Needed for https://github.com/xi-editor/xi-editor/pull/1163

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
