### PR TITLE
Annotations for plugins

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -704,6 +704,18 @@ this writing, the following is valid json for a `Command` object:
     }
 ```
 
+### update_spans
+
+`update_spans {"start": 0, "len": 20, "spans": [{ "start": 1, "end": 3, "scope_id": 4 }], "rev": 3 }`
+
+Updates existing scope spans starting at offset `start` until offset `len`.
+
+### update_annotations
+
+`update_annotations {"start": 0, "len": 20, "spans": [{ "start": 0, "end": 4, "data": null }], "annotation_type": "find", "rev": 3 }`
+
+Updates existing annotations and adds new annotations starting at offset `start` until offset `len`.
+
 ### Language Support Specific Commands
 
 #### Show Hover

--- a/rust/core-lib/src/annotations.rs
+++ b/rust/core-lib/src/annotations.rs
@@ -54,8 +54,8 @@ pub struct AnnotationRange {
 
 impl Serialize for AnnotationRange {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(4))?;
         seq.serialize_element(&self.start_line)?;
@@ -68,8 +68,8 @@ impl Serialize for AnnotationRange {
 
 impl<'de> Deserialize<'de> for AnnotationRange {
     fn deserialize<D>(deserializer: D) -> Result<AnnotationRange, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let mut range = AnnotationRange { ..Default::default() };
         let seq = <[usize; 4]>::deserialize(deserializer)?;
@@ -199,7 +199,7 @@ impl AnnotationStore {
 
         let entry = self.store.get_mut(&source).unwrap();
         if let Some(annotation) =
-        entry.iter_mut().find(|a| a.annotation_type == item.annotation_type)
+            entry.iter_mut().find(|a| a.annotation_type == item.annotation_type)
         {
             annotation.update(interval, item.items);
         } else {

--- a/rust/core-lib/src/annotations.rs
+++ b/rust/core-lib/src/annotations.rs
@@ -131,7 +131,7 @@ impl AnnotationSlice {
         })
     }
 
-    pub fn to_annotations(&self, text: &Rope) -> Annotations {
+    fn to_annotations(&self, text: &Rope) -> Annotations {
         if self.ranges.is_empty() {
             // there are no annotations
             return Annotations {
@@ -183,11 +183,7 @@ impl AnnotationStore {
 
     /// Invalidates and removes all annotations in the range of the interval.
     pub fn invalidate(&mut self, interval: Interval) {
-        for val in self.store.values_mut() {
-            val.clone().into_iter().for_each(|mut r| {
-                r.invalidate(interval);
-            });
-        }
+        self.store.values_mut().map(|v| v.iter_mut()).flatten().for_each(|a| a.invalidate(interval))
     }
 
     /// Applies an update from a plugin to a set of annotations

--- a/rust/core-lib/src/annotations.rs
+++ b/rust/core-lib/src/annotations.rs
@@ -219,6 +219,7 @@ impl AnnotationStore {
 mod tests {
     use super::*;
     use crate::plugins::PluginPid;
+    use crate::xi_rope::spans::SpansBuilder;
 
     #[test]
     fn test_annotation_range_serialization() {

--- a/rust/core-lib/src/annotations.rs
+++ b/rust/core-lib/src/annotations.rs
@@ -14,16 +14,18 @@
 
 //! Management of annotations.
 
-use serde_json::Value;
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeSeq, Serializer};
+use serde_json::{self, Value};
+
 use std::collections::HashMap;
-use std::iter;
 
 use crate::plugins::PluginId;
 use crate::view::View;
-use crate::xi_rope::spans::Spans;
+use crate::xi_rope::spans::{Spans, SpansBuilder};
 use crate::xi_rope::{Interval, Rope};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum AnnotationType {
     Selection,
     Find,
@@ -41,21 +43,71 @@ impl AnnotationType {
 }
 
 /// Location and range of an annotation ([start_line, start_col, end_line, end_col]).
-pub type AnnotationRange = Vec<[usize; 4]>;
+/// Location and range of an annotation
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct AnnotationRange {
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+impl Serialize for AnnotationRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(4))?;
+        seq.serialize_element(&self.start_line)?;
+        seq.serialize_element(&self.start_col)?;
+        seq.serialize_element(&self.end_line)?;
+        seq.serialize_element(&self.end_col)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AnnotationRange {
+    fn deserialize<D>(deserializer: D) -> Result<AnnotationRange, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let mut range = AnnotationRange { ..Default::default() };
+        let seq = <[usize; 4]>::deserialize(deserializer)?;
+
+        range.start_line = seq[0];
+        range.start_col = seq[1];
+        range.end_line = seq[2];
+        range.end_col = seq[3];
+
+        Ok(range)
+    }
+}
 
 /// A set of annotations of a given type.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Annotations {
     pub items: Spans<Value>,
     pub annotation_type: AnnotationType,
 }
 
+impl Annotations {
+    /// Update the annotations in `interval` with the provided `items`.
+    pub fn update(&mut self, interval: Interval, items: Spans<Value>) {
+        self.items.edit(interval, items);
+    }
+
+    /// Remove annotations intersecting `interval`.
+    pub fn invalidate(&mut self, interval: Interval) {
+        self.items.delete_intersecting(interval);
+    }
+}
+
 /// A region of an `Annotation`.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AnnotationSlice {
     annotation_type: AnnotationType,
     /// Annotation occurrences, guaranteed non-descending start order.
-    ranges: AnnotationRange,
+    ranges: Vec<AnnotationRange>,
     /// If present, one payload per range.
     payloads: Option<Vec<Value>>,
 }
@@ -63,7 +115,7 @@ pub struct AnnotationSlice {
 impl AnnotationSlice {
     pub fn new(
         annotation_type: AnnotationType,
-        ranges: AnnotationRange,
+        ranges: Vec<AnnotationRange>,
         payloads: Option<Vec<Value>>,
     ) -> Self {
         AnnotationSlice { annotation_type, ranges, payloads }
@@ -78,6 +130,38 @@ impl AnnotationSlice {
             "n": self.ranges.len()
         })
     }
+
+    pub fn to_annotations(&self, text: &Rope) -> Annotations {
+        if self.ranges.is_empty() {
+            // there are no annotations
+            return Annotations {
+                items: SpansBuilder::new(0).build(),
+                annotation_type: self.annotation_type.clone(),
+            };
+        }
+
+        let span_len = self
+            .ranges
+            .last()
+            .map(|anno_range| text.offset_of_line(anno_range.end_line) + anno_range.end_col)
+            .unwrap();
+
+        let mut sb = SpansBuilder::new(span_len);
+
+        for (i, &range) in self.ranges.iter().enumerate() {
+            let payload = match &self.payloads {
+                Some(p) => p[i].clone(),
+                None => json!(null),
+            };
+
+            let start = text.offset_of_line(range.start_line) + range.start_col;
+            let end = text.offset_of_line(range.end_line) + range.end_col;
+
+            sb.add_span(Interval::new(start, end), payload);
+        }
+
+        Annotations { items: sb.build(), annotation_type: self.annotation_type.clone() }
+    }
 }
 
 /// A trait for types (like `Selection`) that have a distinct representation
@@ -89,34 +173,181 @@ pub trait ToAnnotation {
 
 /// All the annotations for a given view
 pub struct AnnotationStore {
-    _store: HashMap<PluginId, Vec<Annotations>>,
+    store: HashMap<PluginId, Vec<Annotations>>,
 }
 
 impl AnnotationStore {
     pub fn new() -> Self {
-        AnnotationStore { _store: HashMap::new() }
+        AnnotationStore { store: HashMap::new() }
+    }
+
+    /// Invalidates and removes all annotations in the range of the interval.
+    pub fn invalidate(&mut self, interval: Interval) {
+        for val in self.store.values_mut() {
+            val.clone().into_iter().for_each(|mut r| {
+                r.invalidate(interval);
+            });
+        }
     }
 
     /// Applies an update from a plugin to a set of annotations
-    pub fn update(
-        &mut self,
-        _source: PluginId,
-        _type_id: AnnotationType,
-        _iv: Interval,
-        _items: Spans<Value>,
-    ) {
-        // todo
+    pub fn update(&mut self, source: PluginId, interval: Interval, item: Annotations) {
+        if !self.store.contains_key(&source) {
+            self.store.insert(source, vec![item]);
+            return;
+        }
+
+        let entry = self.store.get_mut(&source).unwrap();
+        if let Some(annotation) =
+        entry.iter_mut().find(|a| a.annotation_type == item.annotation_type)
+        {
+            annotation.update(interval, item.items);
+        } else {
+            entry.push(item);
+        }
     }
 
     /// Returns an iterator which produces, for each type of annotation,
     /// those annotations which intersect the given interval.
-    pub fn iter_range<'c>(&'c self, _iv: Interval) -> impl Iterator<Item = AnnotationSlice> + 'c {
-        // todo
-        iter::empty()
+    pub fn iter_range<'c>(
+        &'c self,
+        view: &'c View,
+        text: &'c Rope,
+        interval: Interval,
+    ) -> impl Iterator<Item = AnnotationSlice> + 'c {
+        self.store.iter().flat_map(move |(_plugin, value)| {
+            value.iter().map(move |annotation| {
+                let payloads = annotation
+                    .items
+                    .subseq(interval)
+                    .iter()
+                    .map(|(_i, p)| p.clone())
+                    .collect::<Vec<Value>>();
+
+                let ranges = annotation
+                    .items
+                    .subseq(interval)
+                    .iter()
+                    .map(|(i, _p)| {
+                        let (start_line, start_col) = view.offset_to_line_col(text, i.start());
+                        let (end_line, end_col) = view.offset_to_line_col(text, i.end());
+
+                        AnnotationRange { start_line, start_col, end_line, end_col }
+                    })
+                    .collect::<Vec<AnnotationRange>>();
+
+                AnnotationSlice {
+                    annotation_type: annotation.annotation_type.clone(),
+                    ranges,
+                    payloads: Some(payloads),
+                }
+            })
+        })
     }
 
     /// Removes any annotations provided by this plugin
-    pub fn clear(&mut self, _plugin: PluginId) {
-        // todo
+    pub fn clear(&mut self, plugin: PluginId) {
+        self.store.remove(&plugin);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::PluginPid;
+
+    #[test]
+    fn test_annotation_range_serialization() {
+        let range = AnnotationRange { start_line: 1, start_col: 3, end_line: 4, end_col: 1 };
+
+        assert_eq!(json!(range).to_string(), "[1,3,4,1]")
+    }
+
+    #[test]
+    fn test_annotation_range_deserialization() {
+        let range: AnnotationRange = serde_json::from_str("[1,3,4,1]").unwrap();
+        assert_eq!(range, AnnotationRange { start_line: 1, start_col: 3, end_line: 4, end_col: 1 })
+    }
+
+    #[test]
+    fn test_annotation_slice_json() {
+        let range = AnnotationRange { start_line: 1, start_col: 3, end_line: 4, end_col: 1 };
+
+        let slice = AnnotationSlice {
+            annotation_type: AnnotationType::Find,
+            ranges: vec![range],
+            payloads: None,
+        };
+
+        assert_eq!(
+            slice.to_json().to_string(),
+            "{\"n\":1,\"payloads\":null,\"ranges\":[[1,3,4,1]],\"type\":\"find\"}"
+        )
+    }
+
+    #[test]
+    fn test_annotation_store_update() {
+        let mut store = AnnotationStore::new();
+
+        let mut sb = SpansBuilder::new(10);
+        sb.add_span(Interval::new(1, 5), json!(null));
+
+        assert_eq!(store.store.len(), 0);
+
+        store.update(
+            PluginPid(1),
+            Interval::new(1, 5),
+            Annotations { annotation_type: AnnotationType::Find, items: sb.build() },
+        );
+
+        assert_eq!(store.store.len(), 1);
+
+        sb = SpansBuilder::new(10);
+        sb.add_span(Interval::new(6, 8), json!(null));
+
+        store.update(
+            PluginPid(2),
+            Interval::new(6, 8),
+            Annotations { annotation_type: AnnotationType::Find, items: sb.build() },
+        );
+
+        assert_eq!(store.store.len(), 2);
+    }
+
+    #[test]
+    fn test_annotation_store_clear() {
+        let mut store = AnnotationStore::new();
+
+        let mut sb = SpansBuilder::new(10);
+        sb.add_span(Interval::new(1, 5), json!(null));
+
+        assert_eq!(store.store.len(), 0);
+
+        store.update(
+            PluginPid(1),
+            Interval::new(1, 5),
+            Annotations { annotation_type: AnnotationType::Find, items: sb.build() },
+        );
+
+        assert_eq!(store.store.len(), 1);
+
+        sb = SpansBuilder::new(10);
+        sb.add_span(Interval::new(6, 8), json!(null));
+
+        store.update(
+            PluginPid(2),
+            Interval::new(6, 8),
+            Annotations { annotation_type: AnnotationType::Find, items: sb.build() },
+        );
+
+        assert_eq!(store.store.len(), 2);
+
+        store.clear(PluginPid(1));
+
+        assert_eq!(store.store.len(), 1);
+
+        store.clear(PluginPid(1));
+
+        assert_eq!(store.store.len(), 1);
     }
 }

--- a/rust/core-lib/src/annotations.rs
+++ b/rust/core-lib/src/annotations.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 use crate::plugins::PluginId;
 use crate::view::View;
-use crate::xi_rope::spans::{Spans, SpansBuilder};
+use crate::xi_rope::spans::Spans;
 use crate::xi_rope::{Interval, Rope};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -129,38 +129,6 @@ impl AnnotationSlice {
             "payloads": self.payloads,
             "n": self.ranges.len()
         })
-    }
-
-    fn to_annotations(&self, text: &Rope) -> Annotations {
-        if self.ranges.is_empty() {
-            // there are no annotations
-            return Annotations {
-                items: SpansBuilder::new(0).build(),
-                annotation_type: self.annotation_type.clone(),
-            };
-        }
-
-        let span_len = self
-            .ranges
-            .last()
-            .map(|anno_range| text.offset_of_line(anno_range.end_line) + anno_range.end_col)
-            .unwrap();
-
-        let mut sb = SpansBuilder::new(span_len);
-
-        for (i, &range) in self.ranges.iter().enumerate() {
-            let payload = match &self.payloads {
-                Some(p) => p[i].clone(),
-                None => json!(null),
-            };
-
-            let start = text.offset_of_line(range.start_line) + range.start_col;
-            let end = text.offset_of_line(range.end_line) + range.end_col;
-
-            sb.add_span(Interval::new(start, end), payload);
-        }
-
-        Annotations { items: sb.build(), annotation_type: self.annotation_type.clone() }
     }
 }
 

--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -31,16 +31,15 @@ use crate::plugins::rpc::{
 };
 use crate::rpc::{EditNotification, EditRequest, LineRange, Position as ClientPosition};
 
-use crate::config::{BufferItems, Table};
-use crate::styles::ThemeStyleMap;
-
 use crate::client::Client;
+use crate::config::{BufferItems, Table};
 use crate::edit_types::{EventDomain, SpecialEvent};
 use crate::editor::Editor;
 use crate::file::FileInfo;
 use crate::plugins::Plugin;
 use crate::recorder::Recorder;
 use crate::selection::InsertDrift;
+use crate::styles::ThemeStyleMap;
 use crate::syntax::LanguageId;
 use crate::tabs::{
     BufferId, PluginId, ViewId, FIND_VIEW_IDLE_MASK, RENDER_VIEW_IDLE_MASK, REWRAP_VIEW_IDLE_MASK,
@@ -244,6 +243,11 @@ impl<'a> EventContext<'a> {
             }
             UpdateStatusItem { key, value } => {
                 self.client.update_status_item(self.view_id, &key, &value)
+            }
+            UpdateAnnotations { start, len, spans, annotation_type, rev } => {
+                self.with_editor(|ed, view, _, _| {
+                    ed.update_annotations(view, plugin, start, len, spans, annotation_type, rev)
+                })
             }
             RemoveStatusItem { key } => self.client.remove_status_item(self.view_id, &key),
             ShowHover { request_id, result } => self.do_show_hover(request_id, result),

--- a/rust/core-lib/src/find.rs
+++ b/rust/core-lib/src/find.rs
@@ -17,7 +17,7 @@
 use std::cmp::{max, min};
 use std::iter;
 
-use crate::annotations::{AnnotationSlice, AnnotationType, ToAnnotation};
+use crate::annotations::{AnnotationRange, AnnotationSlice, AnnotationType, ToAnnotation};
 use crate::selection::{InsertDrift, SelRegion, Selection};
 use crate::view::View;
 use crate::word_boundaries::WordCursor;
@@ -416,9 +416,10 @@ impl ToAnnotation for Find {
             .map(|region| {
                 let (start_line, start_col) = view.offset_to_line_col(text, region.min());
                 let (end_line, end_col) = view.offset_to_line_col(text, region.max());
-                [start_line, start_col, end_line, end_col]
+
+                AnnotationRange { start_line, start_col, end_line, end_col }
             })
-            .collect::<Vec<[usize; 4]>>();
+            .collect::<Vec<AnnotationRange>>();
 
         let payload = iter::repeat(json!({"id": self.id})).take(ranges.len()).collect::<Vec<_>>();
 

--- a/rust/core-lib/src/plugins/rpc.rs
+++ b/rust/core-lib/src/plugins/rpc.rs
@@ -22,6 +22,7 @@ use serde::ser::{self, Serialize, Serializer};
 use serde_json::{self, Value};
 
 use super::PluginPid;
+use crate::annotations::AnnotationType;
 use crate::config::Table;
 use crate::syntax::LanguageId;
 use crate::tabs::{BufferIdentifier, ViewId};
@@ -143,6 +144,13 @@ pub struct ScopeSpan {
     pub scope_id: u32,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DataSpan {
+    pub start: usize,
+    pub end: usize,
+    pub data: Value,
+}
+
 /// The object returned by the `get_data` RPC.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetDataResponse {
@@ -157,7 +165,7 @@ pub struct GetDataResponse {
 #[serde(rename_all = "snake_case")]
 pub enum TextUnit {
     /// The requested offset is in bytes. The returned chunk will be valid
-    /// UTF8, and is guaruanteed to include the byte specified the offset.
+    /// UTF8, and is guaranteed to include the byte specified the offset.
     Utf8,
     /// The requested offset is a line number. The returned chunk will begin
     /// at the offset of the requested line.
@@ -179,14 +187,44 @@ pub enum PluginRequest {
 #[serde(tag = "method", content = "params")]
 /// RPC commands sent from plugins.
 pub enum PluginNotification {
-    AddScopes { scopes: Vec<Vec<String>> },
-    UpdateSpans { start: usize, len: usize, spans: Vec<ScopeSpan>, rev: u64 },
-    Edit { edit: PluginEdit },
-    Alert { msg: String },
-    AddStatusItem { key: String, value: String, alignment: String },
-    UpdateStatusItem { key: String, value: String },
-    RemoveStatusItem { key: String },
-    ShowHover { request_id: usize, result: Result<Hover, RemoteError> },
+    AddScopes {
+        scopes: Vec<Vec<String>>,
+    },
+    UpdateSpans {
+        start: usize,
+        len: usize,
+        spans: Vec<ScopeSpan>,
+        rev: u64,
+    },
+    Edit {
+        edit: PluginEdit,
+    },
+    Alert {
+        msg: String,
+    },
+    AddStatusItem {
+        key: String,
+        value: String,
+        alignment: String,
+    },
+    UpdateStatusItem {
+        key: String,
+        value: String,
+    },
+    RemoveStatusItem {
+        key: String,
+    },
+    ShowHover {
+        request_id: usize,
+        result: Result<Hover, RemoteError>,
+    },
+    UpdateAnnotations {
+        start: usize,
+        len: usize,
+        spans: Vec<DataSpan>,
+        annotation_type: AnnotationType,
+        rev: u64,
+    },
 }
 
 /// Range expressed in terms of PluginPosition. Meant to be sent from

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -18,7 +18,7 @@ use std::cmp::{max, min};
 use std::fmt;
 use std::ops::Deref;
 
-use crate::annotations::{AnnotationSlice, AnnotationType, ToAnnotation};
+use crate::annotations::{AnnotationRange, AnnotationSlice, AnnotationType, ToAnnotation};
 use crate::index_set::remove_n_at;
 use crate::view::View;
 use xi_rope::{Interval, Rope, RopeDelta, Transformer};
@@ -234,9 +234,9 @@ impl ToAnnotation for Selection {
             .map(|region| {
                 let (start_line, start_col) = view.offset_to_line_col(text, region.min());
                 let (end_line, end_col) = view.offset_to_line_col(text, region.max());
-                [start_line, start_col, end_line, end_col]
-            })
-            .collect::<Vec<[usize; 4]>>();
+
+                AnnotationRange { start_line, start_col, end_line, end_col }            })
+            .collect::<Vec<AnnotationRange>>();
         AnnotationSlice::new(AnnotationType::Selection, ranges, None)
     }
 }

--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -235,7 +235,8 @@ impl ToAnnotation for Selection {
                 let (start_line, start_col) = view.offset_to_line_col(text, region.min());
                 let (end_line, end_col) = view.offset_to_line_col(text, region.max());
 
-                AnnotationRange { start_line, start_col, end_line, end_col }            })
+                AnnotationRange { start_line, start_col, end_line, end_col }
+            })
             .collect::<Vec<AnnotationRange>>();
         AnnotationSlice::new(AnnotationType::Selection, ranges, None)
     }

--- a/rust/plugin-lib/src/view.rs
+++ b/rust/plugin-lib/src/view.rs
@@ -20,6 +20,8 @@ use crate::xi_core::plugin_rpc::{
     GetDataResponse, PluginBufferInfo, PluginEdit, ScopeSpan, TextUnit,
 };
 use crate::xi_core::{BufferConfig, ConfigTable, LanguageId, PluginPid, ViewId};
+use xi_core_lib::annotations::AnnotationType;
+use xi_core_lib::plugin_rpc::DataSpan;
 use xi_rope::interval::IntervalBounds;
 use xi_rope::RopeDelta;
 use xi_trace::trace_block;
@@ -185,6 +187,25 @@ impl<C: Cache> View<C> {
             "spans": spans,
         });
         self.peer.send_rpc_notification("update_spans", &params);
+    }
+
+    pub fn update_annotations(
+        &self,
+        start: usize,
+        len: usize,
+        annotation_spans: &[DataSpan],
+        annotation_type: &AnnotationType,
+    ) {
+        let params = json!({
+            "plugin_id": self.plugin_id,
+            "view_id": self.view_id,
+            "start": start,
+            "len": len,
+            "rev": self.rev,
+            "spans": annotation_spans,
+            "annotation_type": annotation_type,
+        });
+        self.peer.send_rpc_notification("update_annotations", &params);
     }
 
     pub fn schedule_idle(&self) {


### PR DESCRIPTION
This adds annotation support for plugins. 

A new RPC `update_annotations` is added to the plugin protocol to allow adding, updating and deleting annotations of a specific annotation type. The annotations are represented as spans (`DataSpans`, but maybe a different name might be better?) in the RPC.

When updating annotations, all the annotations that intersect with the interval to be updated will be deleted. For this, it depends on https://github.com/xi-editor/xi-editor/pull/1162 for deleting invalidated annotations.

I also added a bunch of tests which make this PR a bit bloated.

I created a very simple plugin that uses the annotations for testing: https://github.com/scholtzan/xi-todo-highlight and added support to xi-mac on a separate branch https://github.com/scholtzan/xi-mac/tree/todo-annotations. The plugin highlights all the lines that contain "todo" or "fixme" or "note". I wrote the plugin mainly for testing purposes for the annotations. 

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
