### PR TITLE
Add the Vixi project to the list of frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Here are some front-ends in various stages of development:
 
 * [xi-qt](https://github.com/sw5cc/xi-qt), a Qt front-end.
 
+* [vixi](https://github.com/Peltoche/vixi), a Vim like front-end in Rust.
+
 The following are currently inactive, based on earlier versions of the front-end
 protocol, but perhaps could be revitalized:
 


### PR DESCRIPTION
Hi!
Everything is in the title. I have just started a new side-project which consist into a  "Vim like" frontend from the xi-editor. I was hoping to add it to the frontend list inside the README.