### PR TITLE
Fix missing zero length spans for `subseq`

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -55,7 +55,7 @@ pub const MAX_SIZE_LIMIT: usize = 1024 * 1024;
 //want to make this tuneable at runtime, or to be configured by the client.
 /// The render delay after an edit occurs; plugin updates received in this
 /// window will be sent to the view along with the edit.
-const RENDER_DELAY: Duration = Duration::from_millis(2);
+const RENDER_DELAY: Duration = Duration::from_millis(5);
 
 /// A collection of all the state relevant for handling a particular event.
 ///

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -70,9 +70,7 @@ impl<T: Clone> Leaf for SpansLeaf<T> {
         let iv_start = iv.start();
         for span in &other.spans {
             let span_iv = span.iv.intersect(iv).translate_neg(iv_start).translate(self.len);
-            if !span_iv.is_empty() {
-                self.spans.push(Span { iv: span_iv, data: span.data.clone() });
-            }
+             self.spans.push(Span { iv: span_iv, data: span.data.clone() });
         }
         self.len += iv.size();
 
@@ -499,11 +497,22 @@ mod tests {
         sb.add_span(0..3, 0);
         sb.add_span(9..10, 1);
 
-        eprintln!("--");
         let mut spans = sb.build();
         assert_eq!(spans.iter().count(), 2);
 
         spans.delete_intersecting(Interval::new(5, 7));
         assert_eq!(spans.iter().count(), 2);
+    }
+
+    #[test]
+    fn subseq_sub_interval() {
+        let mut sb = SpansBuilder::new(18);
+        sb.add_span(9..9, 0);
+        sb.add_span(11..12, 0);
+        let spans = sb.build();
+
+        assert_eq!(spans.iter().count(), 2);
+        assert_eq!(spans.subseq(0..18).iter().count(), 2);
+        assert_eq!(spans.subseq(0..17).iter().count(), 2);
     }
 }

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -70,7 +70,7 @@ impl<T: Clone> Leaf for SpansLeaf<T> {
         let iv_start = iv.start();
         for span in &other.spans {
             let span_iv = span.iv.intersect(iv).translate_neg(iv_start).translate(self.len);
-             self.spans.push(Span { iv: span_iv, data: span.data.clone() });
+            self.spans.push(Span { iv: span_iv, data: span.data.clone() });
         }
         self.len += iv.size();
 


### PR DESCRIPTION
This fixes https://github.com/xi-editor/xi-editor/issues/1181

I am not sure if there was a good reason for filtering out zero-length interval in `subseq`, but at least none of the tests is failing.

Some background why I was running into this issue: annotations might have a length of zero. I noticed that sometimes these annotations are missing when retrieving plugin annotations for a certain interval: https://github.com/xi-editor/xi-editor/blob/c16973fdad35e222727b3c8e2153b61b1cdd0b0e/rust/core-lib/src/annotations.rs#L193


## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
