### PR TITLE
remove redundant import

### DIFF
--- a/rust/plugin-lib/src/dispatch.rs
+++ b/rust/plugin-lib/src/dispatch.rs
@@ -142,8 +142,6 @@ impl<'a, P: 'a + Plugin> Dispatcher<'a, P> {
     }
 
     fn do_tracing_config(&mut self, enabled: bool) {
-        use xi_trace;
-
         if enabled {
             xi_trace::enable_tracing();
             info!("Enabling tracing in global plugin {:?}", self.pid);


### PR DESCRIPTION
## Summary
Remove redundant import and its associated warning.

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
