### PR TITLE
Remove "collections_range" feature from xi-trace

### DIFF
--- a/rust/trace/Cargo.toml
+++ b/rust/trace/Cargo.toml
@@ -10,7 +10,6 @@ edition = '2018'
 
 [features]
 benchmarks = []
-collections_range = []
 default = ["chrome_trace_event"]
 json_payload = ["serde_json"]
 getpid = []

--- a/rust/trace/src/fixed_lifo_deque.rs
+++ b/rust/trace/src/fixed_lifo_deque.rs
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::cmp::Ordering;
-#[cfg(feature = "collections_range")]
-use std::collections::vec_deque::Drain;
-use std::collections::vec_deque::{IntoIter, Iter, IterMut, VecDeque};
+use std::cmp::{self, Ordering};
+use std::collections::vec_deque::{Drain, IntoIter, Iter, IterMut, VecDeque};
 use std::hash::{Hash, Hasher};
-#[cfg(feature = "collections_range")]
-use std::ops::RangeBounds;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, RangeBounds};
 
 /// Provides fixed size ring buffer that overwrites elements in FIFO order on
 /// insertion when full.  API provided is similar to VecDeque & uses a VecDeque
@@ -134,7 +129,6 @@ impl<T> FixedLifoDeque<T> {
     }
 
     #[inline]
-    #[cfg(feature = "collections_range")]
     pub fn drain<R>(&mut self, range: R) -> Drain<T>
     where
         R: RangeBounds<usize>,


### PR DESCRIPTION
The feature this was guarding (RangeBounds) stablized in 1.28.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [ ] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [ ] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
