### PR TITLE
Copy example preferences file when none found

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -253,6 +253,21 @@ impl ConfigManager {
             extras_dir,
         }
     }
+
+    /// Copies the contents of `client_example.toml` to `preferences.xiconfig`. 
+    /// Used when an existing config file is not found.
+    pub fn create_example_preference_config(&self) -> Result<Option<PathBuf>, ConfigError> {
+        let client_example_config = include_str!("../assets/client_example.toml");
+        
+        if let Some(config_dir) = self.config_dir.as_ref() {
+            let config_file = config_dir.join("preferences.xiconfig");
+            let mut file = fs::File::create(config_file.as_path())?;
+            file.write_all(client_example_config.as_bytes())?;
+            Ok(Some(config_file))    
+        } else {
+            Ok(None)
+        }
+    } 
 
     /// The path of the user's config file, if present.
     pub(crate) fn base_config_file_path(&self) -> Option<PathBuf> {


### PR DESCRIPTION
Previously, xi did not copy the example preferences.xiconfig file when none was found, and simply created an empty file instead. This commit aims to fix that by creating a config file with the contents of preferences.xiconfig to the config folder if one exists.

## Related Issues
Closes [xi-mac #375](https://github.com/xi-editor/xi-mac/issues/375)

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.