### PR TITLE
core-lib: send plugin_started in EventContext::finish_init instead of CoreState::plugin_connect

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -387,7 +387,10 @@ impl<'a> EventContext<'a> {
     pub(crate) fn finish_init(&mut self, config: &Table) {
         if !self.plugins.is_empty() {
             let info = self.plugin_info();
-            self.plugins.iter().for_each(|plugin| plugin.new_buffer(&info));
+            self.plugins.iter().for_each(|plugin| {
+                plugin.new_buffer(&info);
+                self.plugin_started(plugin);
+            });
         }
 
         let available_plugins = self
@@ -475,7 +478,7 @@ impl<'a> EventContext<'a> {
         )
     }
 
-    pub(crate) fn plugin_started(&mut self, plugin: &Plugin) {
+    pub(crate) fn plugin_started(&self, plugin: &Plugin) {
         self.client.plugin_started(self.view_id, &plugin.name)
     }
 

--- a/rust/core-lib/src/tabs.rs
+++ b/rust/core-lib/src/tabs.rs
@@ -905,7 +905,6 @@ impl CoreState {
                 let init_info =
                     self.iter_groups().map(|mut ctx| ctx.plugin_info()).collect::<Vec<_>>();
                 plugin.initialize(init_info);
-                self.iter_groups().for_each(|mut cx| cx.plugin_started(&plugin));
                 self.running_plugins.push(plugin);
             }
             Err(e) => error!("failed to start plugin {:?}", e),


### PR DESCRIPTION
This way we can be sure that if a plugin knows about a view, the view also knows
about that plugin. Without this commit `plugin_started` wouldn't be sent to new
views but only to the ones which exist at the point the plugin has been started.

fixes #1217