### PR TITLE
core-lib: do not set a buffer's default language to "" but to "Plain Text"

### DIFF
--- a/rust/core-lib/src/config.rs
+++ b/rust/core-lib/src/config.rs
@@ -285,7 +285,8 @@ impl ConfigManager {
     ///
     /// Panics if `id` already exists.
     pub(crate) fn add_buffer(&mut self, id: BufferId, path: Option<&Path>) -> Table {
-        let lang = path.and_then(|p| self.language_for_path(p)).unwrap_or_default();
+        let lang =
+            path.and_then(|p| self.language_for_path(p)).unwrap_or(LanguageId::from("Plain Text"));
         let lang_tag = LanguageTag::new(lang);
         assert!(self.buffer_tags.insert(id, lang_tag).is_none());
         self.update_buffer_config(id).expect("new buffer must always have config")


### PR DESCRIPTION
Otherwise we might send "" in the language_changed RPC to the frontend, which
isn't a valid syntax.

fixes #1194