### PR TITLE
core-lib: don't create empty file in FileManager::open

### DIFF
--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -107,7 +107,7 @@ impl FileManager {
 
     pub fn open(&mut self, path: &Path, id: BufferId) -> Result<Rope, FileError> {
         if !path.exists() {
-            let _ = File::create(path).map_err(|e| FileError::Io(e, path.to_owned()))?;
+            return Ok(Rope::from(""));
         }
 
         let (rope, info) = try_load_file(path)?;


### PR DESCRIPTION
Not quite sure if this isn't too simplistic, but at least for me this
seems to work fine.

fixes #1092