### PR TITLE
core-lib: don't error if file permissions can't be recovered in save

### DIFF
--- a/rust/core-lib/src/file.rs
+++ b/rust/core-lib/src/file.rs
@@ -230,7 +230,10 @@ fn try_save(
     #[cfg(target_family = "unix")]
     {
         if let Some(info) = file_info {
-            fs::set_permissions(path, Permissions::from_mode(info.permissions.unwrap_or(0o644)))?;
+            fs::set_permissions(path, Permissions::from_mode(info.permissions.unwrap_or(0o644)))
+                .unwrap_or_else(|e| {
+                    warn!("Couldn't set permissions on file {} due to error {}", path.display(), e)
+                });
         }
     }
 


### PR DESCRIPTION
Some file systems don't support this (typically /run in Linux), which cause
error messages along the line of:

`[2019-09-20][16:28:39][xi_core_lib::tabs][ERROR] File error: "Function not implemented (os error 38). File path: \"/run/user/1000/doc/8f43530e/loremipsum.txt\""`

Yet saving suceeds, it only fails to set the permissions. As such only throw
a warning if this goes wrong.