### PR TITLE
lsp: support sync-kind from SyncOptions

### DIFF
--- a/rust/lsp-lib/src/language_server_client.rs
+++ b/rust/lsp-lib/src/language_server_client.rs
@@ -284,6 +284,10 @@ impl LanguageServerClient {
     pub fn get_sync_kind(&mut self) -> TextDocumentSyncKind {
         match self.server_capabilities.as_ref().and_then(|c| c.text_document_sync.as_ref()) {
             Some(&TextDocumentSyncCapability::Kind(kind)) => kind,
+            Some(TextDocumentSyncCapability::Options(options)) => match options.change {
+                None => TextDocumentSyncKind::None,
+                Some(kind) => kind,
+            },
             _ => TextDocumentSyncKind::Full,
         }
     }


### PR DESCRIPTION
## Summary
Prior to this, the LSP plugin was ignoring language servers specification of the way they want to be synced if they provided it through `TextDocumentSyncOptions`, defaulting to a full sync.

Relevant protocol spec:

> interface ServerCapabilities {
> 	/**
> 	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
> 	 * for backwards compatibility the TextDocumentSyncKind number. If omitted it defaults to `TextDocumentSyncKind.None`.
> 	 */
> 	textDocumentSync?: **TextDocumentSyncOptions** | number;
> 

This means, when working with a language server that makes use of that field (such as [pyls](https://github.com/palantir/python-language-server)), every edit to the document would be synced by sending over the entire file contents.

This small change fixes that.
