### PR TITLE
Replace idle call to finalize_new_views() with immediate call

### DIFF
--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -59,8 +59,8 @@ fn test_state() {
     let write = io::sink();
     let json = make_reader(
         r#"{"method":"client_started","params":{}}
-{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}
-{"id":0,"method":"new_view","params":{}}"#,
+{"id":0,"method":"new_view","params":{"file_path":"../Cargo.toml"}}
+{"method":"set_theme","params":{"theme_name":"InspiredGitHub"}}"#,
     );
     let mut rpc_looper = RpcLoop::new(write);
     rpc_looper.mainloop(|| json, &mut state).unwrap();


### PR DESCRIPTION
## Summary
This change adds a new (failing) test demonstrating #1232 and then a fix, which includes making a synchronous call to finalize_new_views.

## Related Issues
Closes #1232.
Closes #1115.

## Checklist

- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
