### PR TITLE
Bugfix: rendering and updating annotations when scrolling

### DIFF
--- a/rust/core-lib/src/view.rs
+++ b/rust/core-lib/src/view.rs
@@ -733,7 +733,25 @@ impl View {
         plan: &RenderPlan,
         pristine: bool,
     ) {
+        // every time current visible range changes, annotations are sent to frontend
+        let start_off = self.offset_of_line(text, self.first_line);
+        let end_off = self.offset_of_line(text, self.first_line + self.height + 2);
+        let visible_range = Interval::new(start_off, end_off);
+        let selection_annotations =
+            self.selection.get_annotations(visible_range, &self, text).to_json();
+        let find_annotations =
+            self.find.iter().map(|ref f| f.get_annotations(visible_range, &self, text).to_json());
+        let plugin_annotations =
+            self.annotations.iter_range(&self, text, visible_range).map(|a| a.to_json());
+
+        let annotations = iter::once(selection_annotations)
+            .chain(find_annotations)
+            .chain(plugin_annotations)
+            .collect::<Vec<_>>();
+
         if !self.lc_shadow.needs_render(plan) {
+            let update = Update { ops: Vec::new(), pristine, annotations };
+            client.update_view(self.view_id, &update);
             return;
         }
 
@@ -821,21 +839,6 @@ impl View {
         for find in &mut self.find {
             find.set_hls_dirty(false)
         }
-
-        let start_off = self.offset_of_line(text, self.first_line);
-        let end_off = self.offset_of_line(text, self.first_line + self.height + 2);
-        let visible_range = Interval::new(start_off, end_off);
-        let selection_annotations =
-            self.selection.get_annotations(visible_range, &self, text).to_json();
-        let find_annotations =
-            self.find.iter().map(|ref f| f.get_annotations(visible_range, &self, text).to_json());
-        let plugin_annotations =
-            self.annotations.iter_range(&self, text, visible_range).map(|a| a.to_json());
-
-        let annotations = iter::once(selection_annotations)
-            .chain(find_annotations)
-            .chain(plugin_annotations)
-            .collect::<Vec<_>>();
 
         let update = Update { ops, pristine, annotations };
         client.update_view(self.view_id, &update);
@@ -995,6 +998,7 @@ impl View {
         // the front-end, but perhaps not for async edits.
         self.drag_state = None;
 
+        // all annotations that come after the edit need to be invalidated
         let (iv, _) = delta.summary();
         self.annotations.invalidate(iv);
 

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -206,7 +206,9 @@ fn test_settings_commands() {
     rpc_looper.mainloop(|| json, &mut state).unwrap();
     // discard config_changed
     rx.expect_rpc("config_changed");
+    rx.expect_rpc("update");
     rx.expect_rpc("config_changed");
+    rx.expect_rpc("update");
 
     let json = make_reader(r#"{"method":"get_config","id":2,"params":{"view_id":"view-id-1"}}"#);
     rpc_looper.mainloop(|| json, &mut state).unwrap();

--- a/rust/rope/src/spans.rs
+++ b/rust/rope/src/spans.rs
@@ -70,6 +70,7 @@ impl<T: Clone> Leaf for SpansLeaf<T> {
         let iv_start = iv.start();
         for span in &other.spans {
             let span_iv = span.iv.intersect(iv).translate_neg(iv_start).translate(self.len);
+
             if !span_iv.is_empty() {
                 self.spans.push(Span { iv: span_iv, data: span.data.clone() });
             }
@@ -301,18 +302,18 @@ impl<T: Clone> Spans<T> {
         *self = b.build();
     }
 
-    // FIXME: Instead of iterating through all spans every time, another option would be to go
-    // leaf-by-leaf, and check each leaf for whether or not it has any items in the interval;
-    // if they don't we keep them unchanged, otherwise we do this operation, but only within the leaf.
-    //
-    /// Deletes all spans that intersect with `interval`.
-    pub fn delete_intersecting(&mut self, interval: Interval) {
+    /// Deletes all spans that intersect with `interval` and that come after.
+    pub fn delete_after(&mut self, interval: Interval) {
         let mut builder = SpansBuilder::new(self.len());
+
         for (iv, data) in self.iter() {
             // check if spans overlaps with interval
             if iv.intersect(interval).is_empty() {
                 // keep the ones that are not overlapping
                 builder.add_span(iv, data.clone());
+            } else {
+                // all remaining spans are invalid
+                break;
             }
         }
         *self = builder.build();
@@ -447,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_intersecting() {
+    fn test_delete_after() {
         let mut sb = SpansBuilder::new(11);
         sb.add_span(Interval::new(1, 2), 2);
         sb.add_span(Interval::new(3, 5), 8);
@@ -456,32 +457,29 @@ mod tests {
         sb.add_span(Interval::new(10, 11), 1);
         let mut spans = sb.build();
 
-        spans.delete_intersecting(Interval::new(4, 7));
-        let mut deleted_iter = spans.iter();
+        spans.delete_after(Interval::new(4, 7));
 
-        let (iv, val) = deleted_iter.next().unwrap();
+        assert_eq!(spans.iter().count(), 1);
+
+        let (iv, val) = spans.iter().next().unwrap();
         assert_eq!(iv, Interval::new(1, 2));
         assert_eq!(*val, 2);
-
-        let (iv, val) = deleted_iter.next().unwrap();
-        assert_eq!(iv, Interval::new(9, 10));
-        assert_eq!(*val, 1);
     }
 
     #[test]
-    fn delete_intersecting_big_at_start() {
+    fn delete_after_big_at_start() {
         let mut sb = SpansBuilder::new(10);
         sb.add_span(0..10, 0);
 
         let mut spans = sb.build();
         assert_eq!(spans.iter().count(), 1);
 
-        spans.delete_intersecting(Interval::new(1, 2));
+        spans.delete_after(Interval::new(1, 2));
         assert_eq!(spans.iter().count(), 0);
     }
 
     #[test]
-    fn delete_intersecting_big_and_small() {
+    fn delete_after_big_and_small() {
         let mut sb = SpansBuilder::new(10);
         sb.add_span(0..10, 0);
         sb.add_span(3..10, 1);
@@ -489,21 +487,19 @@ mod tests {
         let mut spans = sb.build();
         assert_eq!(spans.iter().count(), 2);
 
-        spans.delete_intersecting(Interval::new(1, 2));
-        assert_eq!(spans.iter().count(), 1);
+        spans.delete_after(Interval::new(1, 2));
+        assert_eq!(spans.iter().count(), 0);
     }
 
     #[test]
-    fn delete_intersecting_empty() {
+    fn delete_after_empty() {
         let mut sb = SpansBuilder::new(10);
         sb.add_span(0..3, 0);
-        sb.add_span(9..10, 1);
 
-        eprintln!("--");
         let mut spans = sb.build();
-        assert_eq!(spans.iter().count(), 2);
+        assert_eq!(spans.iter().count(), 1);
 
-        spans.delete_intersecting(Interval::new(5, 7));
-        assert_eq!(spans.iter().count(), 2);
+        spans.delete_after(Interval::new(5, 7));
+        assert_eq!(spans.iter().count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

While hacking on the [git diff plugin](https://github.com/scholtzan/xiff) I've been working on, I ran into two issues:

1. Existing annotations were incorrectly invalidated. Only annotations that intersected with some edit region were invalidated/deleted. However, that caused some weird behaviour, for example, when deleting some text region that was followed by annotations. In that case all annotations that followed had incorrect offsets. This PR fixes this problem and invalidates all annotations that follow some edit region.

2. Currently, annotations are not cached in the frontend, so every time the visible region changes all annotations of that region need to be sent to the frontend. Before, updates of the view (which annotations are part of) were only sent if the text or selections had changed since frontends cache this information. This resulted in annotations disappearing when scrolling to different regions. This PR fixes this behaviour.

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
