### PR TITLE
xi-unicode can be marked as no_std!

### DIFF
--- a/rust/unicode/src/lib.rs
+++ b/rust/unicode/src/lib.rs
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 //! Unicode utilities useful for text editing, including a line breaking iterator.
+#![no_std]
+
+extern crate alloc;
+
 mod tables;
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::tables::*;
 
@@ -182,7 +186,7 @@ impl LineBreakLeafIter {
     }
 }
 
-fn is_in_asc_list<T: std::cmp::PartialOrd>(c: T, list: &[T], start: usize, end: usize) -> bool {
+fn is_in_asc_list<T: core::cmp::PartialOrd>(c: T, list: &[T], start: usize, end: usize) -> bool {
     if c == list[start] || c == list[end] {
         return true;
     }
@@ -250,6 +254,8 @@ mod tests {
     use crate::linebreak_property;
     use crate::linebreak_property_str;
     use crate::LineBreakIterator;
+    use alloc::vec;
+    use alloc::vec::*;
 
     #[test]
     fn linebreak_prop() {


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
This PR marks the library as `no_std` since all of its `std` API usage exists in `core`. This is helpful for embedding in environments where `std` isn't available, like the web. 



<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
Closes: https://github.com/xi-editor/xi-editor/issues/1250

<!---
GitHub has built-in functionality for closing issues when PR's are merged. TLDR: `closes #1` closes issue number 1 when the PR merges.
See [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) for more info.
--->

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
