### PR TITLE
Merging selections now preserves the direction of the most recent

### DIFF
--- a/rust/core-lib/src/selection.rs
+++ b/rust/core-lib/src/selection.rs
@@ -103,7 +103,7 @@ impl Selection {
         let mut end_ix = ix;
         if self.regions[ix].min() <= region.min() {
             if self.regions[ix].should_merge(region) {
-                region = self.regions[ix].merge_with(region);
+                region = region.merge_with(self.regions[ix]);
             } else {
                 ix += 1;
             }
@@ -343,8 +343,10 @@ impl SelRegion {
             || ((self.is_caret() || other.is_caret()) && other.min() == self.max())
     }
 
+    // Merge self with an overlapping region.
+    // Retains direction of self.
     fn merge_with(self, other: SelRegion) -> SelRegion {
-        let is_forward = self.end > self.start || other.end > other.start;
+        let is_forward = self.end >= self.start;
         let new_min = min(self.min(), other.min());
         let new_max = max(self.max(), other.max());
         let (start, end) = if is_forward { (new_min, new_max) } else { (new_max, new_min) };
@@ -495,6 +497,8 @@ mod tests {
         assert_eq!(s.deref(), &[r(1, 3), r(3, 6), r(7, 9)]);
         s.add_region(r(2, 8));
         assert_eq!(s.deref(), &[r(1, 9)]);
+        s.add_region(r(10, 8));
+        assert_eq!(s.deref(), &[r(10, 1)]);
 
         s.clear();
         assert_eq!(s.deref(), &[]);


### PR DESCRIPTION
<!---
Welcome to the xi-editor project! We're very excited for your contribution to become a part of the editor.
This template provides some basic instructions on how to format a pull request, so we can more easily understand it.
Anything within this commented block will not be a part of the visible text.

The first part of your pull request should be a summary describing its intent. This is also an appropriate place to explain the motivation behind the changes it introduces.
--->
## Summary
Merging 2 selections if one is forward and one is backward, now follows the direction of the more recent instead of always forward.



<!---
Give reviewers and interested parties a good idea of how this is related to other issues or pull requests.
--->
## Related Issues
Related to #323

<!---
GitHub has built-in functionality for closing issues when PR's are merged. TLDR: `closes #1` closes issue number 1 when the PR merges.
See [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/) for more info.
--->
closes #323

<!---
Checklists are a useful tool for tracking your progress with longer pull requests. It gives reviewers a clear idea of how far you've come, and what can be reviewed. It's also fun to check off those boxes!
--->

## Review Checklist
<!---
Here is a list of the things everyone should make sure they do before they want their PR to be merged.
--->
- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
