### PR TITLE
declare minimum rust version as 1.40.0 (for `mem::take`)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,7 @@ description = "Main process for xi-core, based on json-rpc"
 categories = ["text-editors"]
 repository = "https://github.com/xi-editor/xi-editor"
 edition = '2018'
+rust = "1.40"
 
 [dependencies]
 serde = "1.0"


### PR DESCRIPTION
In practice, this has little effect,
as this setting is only supported in the latest cargo versions anyway,
so users with an outdated rust setup
will still not get a nice error message.
It does not hurt though,
and maybe they stumble over it in the config file.

closes #1273
