### PR TITLE
Can xi-unicode be published with a new version?

### DIFF
--- a/rust/unicode/Cargo.toml
+++ b/rust/unicode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xi-unicode"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph@google.com>"]
 repository = "https://github.com/google/xi-editor"


### PR DESCRIPTION
I made the `no_std` PR back in March and I would like to use `xi-unicode` it from crates.io with that :3. Could a maintainer increment the version and mark a release onto crates?

