### PR TITLE
Fix panic in is_simple_delete

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -90,7 +90,7 @@ impl<N: NodeInfo> Delta<N> {
 
     /// Returns `true` if this delta represents a single deletion without
     /// any insertions.
-    /// 
+    ///
     /// Note that this is `false` for the trivial delta, as well as for a deletion
     /// from an empty `Rope`.
     pub fn is_simple_delete(&self) -> bool {

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -91,8 +91,8 @@ impl<N: NodeInfo> Delta<N> {
     /// Returns `true` if this delta represents a single deletion without
     /// any insertions. Note that this is `false` for the trivial delta.
     pub fn is_simple_delete(&self) -> bool {
-        if self.els.is_empty() && self.base_len > 0 {
-            return true;
+        if self.els.is_empty() {
+            return self.base_len > 0;
         }
         if let DeltaElement::Copy(beg, end) = self.els[0] {
             if beg == 0 {
@@ -827,6 +827,9 @@ mod tests {
     #[test]
     fn is_simple_delete() {
         let d = Delta::simple_edit(10..12, Rope::from("+"), TEST_STR.len());
+        assert_eq!(false, d.is_simple_delete());
+
+        let d = Delta::simple_edit(Interval::new(0, 0), Rope::from(""), 0);
         assert_eq!(false, d.is_simple_delete());
 
         let d = Delta::simple_edit(Interval::new(10, 11), Rope::from(""), TEST_STR.len());

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -89,7 +89,10 @@ impl<N: NodeInfo> Delta<N> {
     }
 
     /// Returns `true` if this delta represents a single deletion without
-    /// any insertions. Note that this is `false` for the trivial delta.
+    /// any insertions.
+    /// 
+    /// Note that this is `false` for the trivial delta, as well as for a deletion
+    /// from an empty `Rope`.
     pub fn is_simple_delete(&self) -> bool {
         if self.els.is_empty() {
             return self.base_len > 0;


### PR DESCRIPTION
In `is_simple_delete`, it is possible that `els.is_empty()` is true while `self.base_len > 0` is false - it can occur when the buffer is empty and the user tries to delete something.
In that case the statement in the `if let` below will then try to access a nonexisting element, causing a panic.

This PR fixes this.

- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
