### PR TITLE
Fix panics in `do_insert_tab`

### DIFF
--- a/rust/core-lib/src/event_context.rs
+++ b/rust/core-lib/src/event_context.rs
@@ -1560,6 +1560,13 @@ mod tests {
 
         ctx.do_edit(EditNotification::Outdent);
         assert_eq!(harness.debug_render(),"[|    hello\n]world");
+
+        ctx.do_edit(EditNotification::SelectAll);
+        ctx.do_edit(EditNotification::DeleteBackward);
+        ctx.do_edit(EditNotification::Insert { chars: "hello".into() });
+        ctx.do_edit(EditNotification::SelectAll);
+        ctx.do_edit(EditNotification::InsertTab);
+        assert_eq!(harness.debug_render(),"    |");
     }
 
     #[test]


### PR DESCRIPTION
This PR resolves some regressions introduced in PR #1263.

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [ ] I have rebased my PR branch onto xi-editor/master.
