### PR TITLE
Fix is_identity

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -116,13 +116,16 @@ impl<N: NodeInfo> Delta<N> {
 
     /// Returns `true` if applying the delta will cause no change.
     pub fn is_identity(&self) -> bool {
-        if self.els.len() == 1 {
+        let len = self.els.len();
+        // Case 1: Everything from beginning to end is getting copied.
+        if len == 1 {
             if let DeltaElement::Copy(beg, end) = self.els[0] {
                 return beg == 0 && end == self.base_len;
             }
         }
 
-        false
+        // Case 2: The rope is empty and the entire rope is getting deleted.
+        len == 0 && self.base_len == 0
     }
 
     /// Apply the delta to the given rope. May not work well if the length of the rope
@@ -860,6 +863,9 @@ mod tests {
         assert_eq!(false, d.is_identity());
 
         let d = Delta::simple_edit(0..0, Rope::from(""), TEST_STR.len());
+        assert_eq!(true, d.is_identity());
+
+        let d = Delta::simple_edit(0..0, Rope::from(""), 0);
         assert_eq!(true, d.is_identity());
     }
 


### PR DESCRIPTION
There was a second case in which applying a delta would not result in any change: deleting everyting while the rope is empty.

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
