### PR TITLE
Stay within cache boundaries in `base_cache.rs`.

### DIFF
--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -333,7 +333,7 @@ impl ChunkCache {
         if start < self.offset || start > self.offset + self.contents.len() {
             true
         } else if delta.is_simple_delete() {
-            self.simple_delete(start, end);
+            self.simple_delete(start, std::cmp::min(end, self.offset + self.contents.len()));
             false
         } else if let Some(text) = delta.as_simple_insert() {
             assert_eq!(iv.size(), 0);
@@ -701,6 +701,30 @@ mod tests {
         c.simple_delete(start, end);
 
         assert_eq!(&c.line_offsets, &[7, 11]);
+    }
+
+    #[test]
+    fn large_delete() {
+        // Issue #1136 on github
+        let large_str = "This string literal is larger than CHUNK_SIZE.";
+        assert!(large_str.len() > CHUNK_SIZE);
+
+        let data = GetDataResponse {
+            // Emulate a cache that has only a part of the buffer.
+            chunk: large_str.split_at(CHUNK_SIZE).0.into(),
+            offset: 0,
+            first_line: 0,
+            first_line_offset: 0,
+        };
+        let mut c = ChunkCache::default();
+        c.reset_chunk(data);
+
+        // This delta deletes everything.
+        let delta =
+            Delta::simple_edit(Interval::new(0, large_str.len()), "".into(), large_str.len());
+        assert!(delta.is_simple_delete());
+
+        c.update(Some(&delta), delta.new_document_len(), 1, 1); // Should succeed
     }
 
     #[test]

--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -333,7 +333,10 @@ impl ChunkCache {
         if start < self.offset || start > self.offset + self.contents.len() {
             true
         } else if delta.is_simple_delete() {
-            self.simple_delete(start, std::cmp::min(end, self.offset + self.contents.len()));
+            // Don't go over cache boundary.
+            let end = end.min(self.offset + self.contents.len());
+            
+            self.simple_delete(start, end);
             false
         } else if let Some(text) = delta.as_simple_insert() {
             assert_eq!(iv.size(), 0);

--- a/rust/plugin-lib/src/base_cache.rs
+++ b/rust/plugin-lib/src/base_cache.rs
@@ -335,7 +335,7 @@ impl ChunkCache {
         } else if delta.is_simple_delete() {
             // Don't go over cache boundary.
             let end = end.min(self.offset + self.contents.len());
-            
+
             self.simple_delete(start, end);
             false
         } else if let Some(text) = delta.as_simple_insert() {


### PR DESCRIPTION
When recieving a delta, the plugin library would sometimes try to adjust its cache so it doesn't have to be discarded.
It does this without properly checking the delta's bounds, resulting in a panic like in #1136.
This PR fixes this and thus fixes #1136 .

- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
