### PR TITLE
Expose push_subseq method on TreeBuilder

### DIFF
--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -138,7 +138,7 @@ impl<N: NodeInfo> Delta<N> {
         let mut b = TreeBuilder::new();
         for elem in &self.els {
             match *elem {
-                DeltaElement::Copy(beg, end) => b.push_subseq(base, Interval::new(beg, end)),
+                DeltaElement::Copy(beg, end) => b.push_slice(base, Interval::new(beg, end)),
                 DeltaElement::Insert(ref n) => b.push(n.clone()),
             }
         }

--- a/rust/rope/src/delta.rs
+++ b/rust/rope/src/delta.rs
@@ -138,7 +138,7 @@ impl<N: NodeInfo> Delta<N> {
         let mut b = TreeBuilder::new();
         for elem in &self.els {
             match *elem {
-                DeltaElement::Copy(beg, end) => base.push_subseq(&mut b, Interval::new(beg, end)),
+                DeltaElement::Copy(beg, end) => b.push_subseq(base, Interval::new(beg, end)),
                 DeltaElement::Insert(ref n) => b.push(n.clone()),
             }
         }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -147,7 +147,7 @@ impl Subset {
     pub fn delete_from<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
         for (beg, end) in self.range_iter(CountMatcher::Zero) {
-            b.push_subseq(s, Interval::new(beg, end));
+            b.push_slice(s, Interval::new(beg, end));
         }
         b.build()
     }

--- a/rust/rope/src/multiset.rs
+++ b/rust/rope/src/multiset.rs
@@ -147,7 +147,7 @@ impl Subset {
     pub fn delete_from<N: NodeInfo>(&self, s: &Node<N>) -> Node<N> {
         let mut b = TreeBuilder::new();
         for (beg, end) in self.range_iter(CountMatcher::Zero) {
-            s.push_subseq(&mut b, Interval::new(beg, end));
+            b.push_subseq(s, Interval::new(beg, end));
         }
         b.build()
     }


### PR DESCRIPTION
It's cleaner to have this method on TreeBuilder than Tree. It's also a
useful an important method; the general template for any incremental
algorithm is to use a TreeBuilder to assemble its result, and I think we
should encourage its use.

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
