### PR TITLE
More base cases in rope diffing.

### DIFF
--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -173,7 +173,8 @@ fn hash_diff_big(b: &mut Bencher) {
 
 #[bench]
 fn simple_insertion(b: &mut Bencher) {
-    let one: Rope = ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
+    let one: Rope =
+        ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
     let two = "startend".into();
     let mut delta: Option<RopeDelta> = None;
     b.iter(|| {
@@ -186,7 +187,8 @@ fn simple_insertion(b: &mut Bencher) {
 
 #[bench]
 fn simple_deletion(b: &mut Bencher) {
-    let one: Rope = ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
+    let one: Rope =
+        ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
     let two = "startend".into();
     let mut delta: Option<RopeDelta> = None;
     b.iter(|| {

--- a/rust/rope/benches/diff.rs
+++ b/rust/rope/benches/diff.rs
@@ -170,3 +170,29 @@ fn hash_diff_big(b: &mut Bencher) {
     let _result = delta.unwrap().apply(&one);
     assert_eq!(String::from(_result), String::from(&two));
 }
+
+#[bench]
+fn simple_insertion(b: &mut Bencher) {
+    let one: Rope = ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
+    let two = "startend".into();
+    let mut delta: Option<RopeDelta> = None;
+    b.iter(|| {
+        delta = Some(LineHashDiff::compute_delta(&one, &two));
+    });
+
+    let _result = delta.unwrap().apply(&one);
+    assert_eq!(String::from(_result), String::from(&two));
+}
+
+#[bench]
+fn simple_deletion(b: &mut Bencher) {
+    let one: Rope = ["start", EDITOR_STR, VIEW_STR, INTERVAL_STR, BREAKS_STR, "end"].concat().into();
+    let two = "startend".into();
+    let mut delta: Option<RopeDelta> = None;
+    b.iter(|| {
+        delta = Some(LineHashDiff::compute_delta(&two, &one));
+    });
+
+    let _result = delta.unwrap().apply(&two);
+    assert_eq!(String::from(_result), String::from(&one));
+}


### PR DESCRIPTION
Extracted from #1284, this patch allows the rope diffing algorithm to finish early in more situations.
Includes a bechmark:
```
Before patch:
test simple_insertion ... bench:     208,509 ns/iter (+/- 21,198)
test simple_deletion  ... bench:     185,520 ns/iter (+/- 23,425)

After patch:
test simple_insertion ... bench:         267 ns/iter (+/- 48)
test simple_deletion  ... bench:       5,097 ns/iter (+/- 612)
```

## Review Checklist

- [ ] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
