### PR TITLE
Implement UpdateOp::update and fix line invalidation in the middle of the cache

### DIFF
--- a/docs/docs/frontend-protocol.md
+++ b/docs/docs/frontend-protocol.md
@@ -553,9 +553,10 @@ in more detail below. For this op, `n` must equal `lines.length` (alternative:
 make n optional in this case). It does not update `old_ix`.
 
 The "update" op updates the cursor and/or style of n existing lines. As in
-"ins", n must equal lines.length. It also increments `old_ix` by `n`.
-
-**Note:** The "update" op is not currently used by core.
+"ins", n must equal lines.length. It also increments `old_ix` by `n`. If the
+update modifies the line numbers of the given n lines, the `ln` parameter
+representing the new logical line number of the first line (as in the "copy"
+op) should be present.
 
 In all cases, n is guaranteed positive and nonzero (as a consequence, any line
 present in the old state is copied at most once to the new state).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1184,13 +1184,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-rpc 0.3.0",
 ]
 
 [[package]]
 name = "xi-core-lib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1219,7 +1219,7 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pom 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.3.0",
  "xi-trace 0.2.0",
@@ -1238,7 +1238,7 @@ dependencies = [
  "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.3.0",
  "xi-rpc 0.3.0",
@@ -1256,7 +1256,7 @@ dependencies = [
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-rope 0.3.0",
  "xi-rpc 0.3.0",
  "xi-trace 0.2.0",
@@ -1293,7 +1293,7 @@ version = "0.0.0"
 dependencies = [
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.3.0",
  "xi-trace 0.2.0",
@@ -1308,7 +1308,7 @@ dependencies = [
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.3.0",
+ "xi-core-lib 0.4.0",
  "xi-plugin-lib 0.1.0",
  "xi-rope 0.3.0",
  "xi-trace 0.2.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xi-core"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph@google.com>"]
 description = "Main process for xi-core, based on json-rpc"

--- a/rust/core-lib/Cargo.toml
+++ b/rust/core-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xi-core-lib"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 authors = ["Raph Levien <raph@google.com>"]
 description = "Library module for xi-core"

--- a/rust/core-lib/src/client.rs
+++ b/rust/core-lib/src/client.rs
@@ -271,6 +271,15 @@ impl UpdateOp {
     pub(crate) fn insert(lines: Vec<Value>) -> Self {
         UpdateOp { op: OpType::Insert, n: lines.len(), lines: Some(lines), first_line_number: None }
     }
+
+    pub(crate) fn update(lines: Vec<Value>, line_opt: Option<usize>) -> Self {
+        UpdateOp {
+            op: OpType::Update,
+            n: lines.len(),
+            lines: Some(lines),
+            first_line_number: line_opt,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -281,4 +290,5 @@ enum OpType {
     Skip,
     Invalidate,
     Copy,
+    Update,
 }

--- a/rust/core-lib/src/core.rs
+++ b/rust/core-lib/src/core.rs
@@ -50,10 +50,7 @@ impl XiCore {
 
     /// Returns `true` if the `client_started` has not been received.
     fn is_waiting(&self) -> bool {
-        match *self {
-            XiCore::Waiting => true,
-            _ => false,
-        }
+        matches!(*self, XiCore::Waiting)
     }
 
     /// Returns a guard to the core state. A convenience around `Mutex::lock`.

--- a/rust/core-lib/src/plugins/manifest.rs
+++ b/rust/core-lib/src/plugins/manifest.rs
@@ -219,10 +219,7 @@ impl PlaceholderRpc {
 impl PluginDescription {
     /// Returns `true` if this plugin is globally scoped, else `false`.
     pub fn is_global(&self) -> bool {
-        match self.scope {
-            PluginScope::Global => true,
-            _ => false,
-        }
+        matches!(self.scope, PluginScope::Global)
     }
 }
 

--- a/rust/core-lib/src/syntax.rs
+++ b/rust/core-lib/src/syntax.rs
@@ -23,6 +23,8 @@ use crate::config::Table;
 
 /// The canonical identifier for a particular `LanguageDefinition`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[allow(clippy::rc_buffer)] // suppress clippy;  TODO consider addressing
+                            // the warning by changing String to str
 pub struct LanguageId(Arc<String>);
 
 /// Describes a `LanguageDefinition`. Although these are provided by plugins,

--- a/rust/core-lib/tests/rpc.rs
+++ b/rust/core-lib/tests/rpc.rs
@@ -170,6 +170,7 @@ fn test_invalidate() {
     }
 
     // Dump the last vector of ops.
+    // Verify that there is an "update" op in case of a cursor motion.
     assert_eq!(
         last_ops
             .iter()
@@ -178,7 +179,7 @@ fn test_invalidate() {
                 (op_in["op"].as_str().unwrap(), op_in["n"].as_u64().unwrap())
             })
             .collect::<Vec<_>>(),
-        [("copy", 1), ("invalidate", 1), ("skip", 1), ("copy", 5), ("copy", 11), ("ins", 1), ("ins", 1)]
+        [("copy", 1), ("update", 1), ("copy", 5), ("copy", 11), ("update", 2)]
     );
 }
 

--- a/rust/rope/src/engine.rs
+++ b/rust/rope/src/engine.rs
@@ -326,7 +326,7 @@ impl Engine {
     /// A delta that, when applied to `base_rev`, results in the current head. Returns
     /// an error if there is not at least one edit.
     pub fn try_delta_rev_head(&self, base_rev: RevToken) -> Result<Delta<RopeInfo>, Error> {
-        let ix = self.find_rev_token(base_rev).ok_or_else(|| Error::MissingRevision(base_rev))?;
+        let ix = self.find_rev_token(base_rev).ok_or(Error::MissingRevision(base_rev))?;
         let prev_from_union = self.deletes_from_cur_union_for_index(ix);
         // TODO: this does 2 calls to Delta::synthesize and 1 to apply, this probably could be better.
         let old_tombstones = shuffle_tombstones(
@@ -351,7 +351,7 @@ impl Engine {
         base_rev: RevToken,
         delta: Delta<RopeInfo>,
     ) -> Result<(Revision, Rope, Rope, Subset), Error> {
-        let ix = self.find_rev_token(base_rev).ok_or_else(|| Error::MissingRevision(base_rev))?;
+        let ix = self.find_rev_token(base_rev).ok_or(Error::MissingRevision(base_rev))?;
 
         let (ins_delta, deletes) = delta.factor();
 

--- a/rust/rpc/src/error.rs
+++ b/rust/rpc/src/error.rs
@@ -128,10 +128,7 @@ impl RemoteError {
 impl ReadError {
     /// Returns `true` iff this is the `ReadError::Disconnect` variant.
     pub fn is_disconnect(&self) -> bool {
-        match *self {
-            ReadError::Disconnect => true,
-            _ => false,
-        }
+        matches!(*self, ReadError::Disconnect)
     }
 }
 

--- a/rust/syntect-plugin/src/main.rs
+++ b/rust/syntect-plugin/src/main.rs
@@ -447,7 +447,7 @@ impl<'a> PluginState {
             Err(e) => return Err(e),
         };
         let metadata =
-            self.get_metadata(view, syntax_set, prev_line).ok_or_else(|| Error::PeerDisconnect)?;
+            self.get_metadata(view, syntax_set, prev_line).ok_or(Error::PeerDisconnect)?;
         let line = view.get_line(prev_line)?;
 
         let comment_str = match metadata.line_comment().map(|s| s.to_owned()) {
@@ -474,8 +474,7 @@ impl<'a> PluginState {
         if line == 0 {
             return Ok(false);
         }
-        let metadata =
-            self.get_metadata(view, syntax_set, line).ok_or_else(|| Error::PeerDisconnect)?;
+        let metadata = self.get_metadata(view, syntax_set, line).ok_or(Error::PeerDisconnect)?;
         let line = view.get_line(line)?;
         Ok(metadata.decrease_indent(line))
     }

--- a/rust/syntect-plugin/src/stackmap.rs
+++ b/rust/syntect-plugin/src/stackmap.rs
@@ -90,10 +90,7 @@ impl StackMap {
 
 impl LookupResult {
     pub fn is_new(&self) -> bool {
-        match *self {
-            LookupResult::New(_) => true,
-            _ => false,
-        }
+        matches!(*self, LookupResult::New(_))
     }
 }
 


### PR DESCRIPTION
## Summary
This change introduces a new UpdateOp, "update", in addition to "copy", "insert", "invalidate" and "skip".

This UpdateOp was outlined in the design docs before me but was never actually implemented.

UpdateOp::update will be sent by View::send_update_for_plan() in case of an update of a line cache shadow segment if this update only moves the cursor (!CURSOR_VALID) and leaves the text and styles intact (TEXT_VALID && STYLES_VALID).

As a side effect, this change fixes the problem with an "invalidate" op showing up in the middle of the vector of ops.

It also fixes a couple minor bugs in line/region overlaps calculation in View::render_line().

This change requires the frontends to implement the support for UpdateOp::update (if not done already).

Because of the incompatible change in behavior, xi-core version is bumped to 0.4.


## Related Issues
Fixes #1301 
Fixes #1228 


## Review Checklist
- [x] I have responded to reviews and made changes where appropriate.
- [x] I have tested the code with `cargo test --all` / `./rust/run_all_checks`.
- [x] I have updated comments / documentation related to the changes I made.
- [x] I have rebased my PR branch onto xi-editor/master.
